### PR TITLE
Excel export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ RdMacros:
     lifecycle
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,9 @@ Suggests:
     withr
 Remotes:
     poissonconsulting/flobr,
-    poissonconsulting/dbflobr
+    poissonconsulting/dbflobr,
+    poissonconsulting/poissqlite,
+    poissonconsulting/poisspatial
 RdMacros: 
     lifecycle
 Encoding: UTF-8

--- a/R/save.R
+++ b/R/save.R
@@ -809,25 +809,35 @@ sbf_save_datas_to_db <- function(db_name = sbf_get_db_name(), sub = sbf_get_sub(
 #'
 #' Converts a database to an single excel workbook where each table is its own
 #' spreadsheet.
-#' 
+#' @param exclude_tables A regular expression listing tables to be excluded.
 #' @inheritParams sbf_save_workbook
 #' @inheritParams sbf_open_db
 #' @family excel
 #' @examples 
 #' \dontrun{
 #' sbf_save_db_to_workbook()
+#' 
+#' # exclude the sites table
+#' sbf_save_db_to_workbook(exclude_tables = "sites")
+#' 
+#' # exclude the sites and species table
+#' sbf_save_db_to_workbook(exclude_tables = "sites|species")
 #' }
 #' @export
 
 sbf_save_db_to_workbook <- function(workbook_name = sbf_get_workbook_name(), 
                                     db_name = sbf_get_db_name(), 
+                                    exclude_tables = "^$",
                                     sub = sbf_get_sub(), 
                                     main = sbf_get_main(), 
                                     epgs = NULL) {
+  chk::chk_string(exclude_tables)
   
   conn <- sbf_open_db(db_name, sub = sub, main = main)
   on.exit(sbf_close_db(conn))
   datas <- rws_read(conn)
+  # exclude listed tables
+  datas <- datas[datas = !grepl(exclude_tables, names(datas))]
   sbf_save_workbook(datas, workbook_name, sub, main, epgs)
   invisible(names(datas))
 }

--- a/R/save.R
+++ b/R/save.R
@@ -530,8 +530,8 @@ sbf_save_excel <- function(x,
 
 #' Save Dataframes to Excel Workbook
 #'
-#' This takes the data frames from the working environment and saves them to a
-#' single excel workbook where each table is its own spreadsheet
+#' This takes the data frames from the environment and saves them to a
+#' single excel workbook where each table is its own spreadsheet.
 #'   
 #' @param epgs The projection to convert to
 #' @param workbook_name The name of the excel workbook you are creating. Default

--- a/man/sbf_save_db_to_workbook.Rd
+++ b/man/sbf_save_db_to_workbook.Rd
@@ -7,6 +7,7 @@
 sbf_save_db_to_workbook(
   workbook_name = sbf_get_workbook_name(),
   db_name = sbf_get_db_name(),
+  exclude_tables = "^$",
   sub = sbf_get_sub(),
   main = sbf_get_main(),
   epgs = NULL
@@ -17,6 +18,8 @@ sbf_save_db_to_workbook(
 is the base name of the current working directory.}
 
 \item{db_name}{A string of the database name.}
+
+\item{exclude_tables}{A regular expression listing tables to be excluded.}
 
 \item{sub}{A string specifying the path to the sub folder (by default the current sub folder).}
 
@@ -31,6 +34,12 @@ spreadsheet.
 \examples{
 \dontrun{
 sbf_save_db_to_workbook()
+
+# exclude the sites table
+sbf_save_db_to_workbook(exclude_tables = "sites")
+
+# exclude the sites and species table
+sbf_save_db_to_workbook(exclude_tables = "sites|species")
 }
 }
 \seealso{

--- a/man/sbf_save_workbook.Rd
+++ b/man/sbf_save_workbook.Rd
@@ -28,8 +28,8 @@ is the base name of the current working directory.}
 An invisible string of the path to the saved data.frame
 }
 \description{
-This takes the data frames from the working environment and saves them to a
-single excel workbook where each table is its own spreadsheet
+This takes the data frames from the environment and saves them to a
+single excel workbook where each table is its own spreadsheet.
 }
 \examples{
 \dontrun{

--- a/man/sbf_save_workbook.Rd
+++ b/man/sbf_save_workbook.Rd
@@ -5,16 +5,14 @@
 \title{Save Dataframes to Excel Workbook}
 \usage{
 sbf_save_workbook(
-  x,
   workbook_name = basename(getwd()),
   sub = sbf_get_sub(),
   main = sbf_get_main(),
+  env = parent.frame(),
   epgs = NULL
 )
 }
 \arguments{
-\item{x}{The data frames as a named list}
-
 \item{workbook_name}{The name of the excel workbook you are creating. Default
 is the base name of the current working directory.}
 
@@ -22,14 +20,16 @@ is the base name of the current working directory.}
 
 \item{main}{A string specifying the path to the main folder (by default the current main folder)}
 
+\item{env}{An environment.}
+
 \item{epgs}{The projection to convert to}
 }
 \value{
 An invisible string of the path to the saved data.frame
 }
 \description{
-This takes the data frames and saves them to a single excel workbook where
-each table is its own spreadsheet
+This takes the data frames from the working environment and saves them to a
+single excel workbook where each table is its own spreadsheet
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -889,7 +889,7 @@ test_that("save two dataframes as excel workbook", {
   
   data <- list(sites = sites, species = species)
 
-  sbf_save_workbook(data, "data")
+  sbf_save_workbook("data")
 
   site_data <- readxl::read_excel(file.path(path, "excel/data.xlsx"), 
                                   sheet = "sites")
@@ -979,3 +979,33 @@ test_that("exclude table function working for db to workbook", {
                                      sheet = 2))
 })
 
+test_that("expect empty table when all tables are excluded", {
+  
+  sbf_reset()
+  path <- file.path(withr::local_tempdir(), "output")
+  sbf_set_main(path)
+  withr::defer(sbf_reset())
+  
+  # create test data
+  sites <- data.frame(Places =  c("Yakoun Lake", "Meyer Lake"),
+                      Activity = c("boating", "fishing"))
+  
+  
+  sbf_create_db(db_name = "database")
+  
+  sbf_execute_db("CREATE TABLE sites (
+                Places TEXT,
+                Activity TEXT)")
+  
+  sbf_save_data_to_db(sites, db_name = "database")
+  
+  # write db to excel tables
+  sbf_save_db_to_workbook(workbook_name = "data", 
+                          db_name = "database", 
+                          exclude_tables = "sites")
+  # do tests
+  data <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
+  
+  expect_equal(nrow(data), 0L)
+  expect_equal(colnames(data), character(0))
+})


### PR DESCRIPTION
- correcting description error by adding missing packages to remotes
- switching `sbf_save_workbook()` to pull from the environment not to take a named listed ( close #23 )
- this caused minor changes to `sbf_save_db_to_workbook()` internals 
- added a parameter to `sbf_save_db_to_workbook()` to exclude tables based on regex ( close #21 )
