### PR TITLE
pkgdown action updates

### DIFF
--- a/.github/workflows/pkgdown-dev.yaml
+++ b/.github/workflows/pkgdown-dev.yaml
@@ -10,7 +10,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: macOS-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PRIVATE_ACTIONS_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/pkgdown-dev.yaml
+++ b/.github/workflows/pkgdown-dev.yaml
@@ -1,0 +1,58 @@
+on:
+  push:
+    branches: 
+      - dev
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_dev("pkgdown")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Deploy package
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::build_site()'
+
+      - name: action-slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: 8398a7/action-slack@v3.0.0
+        with:
+          status: ${{ job.status }}
+          author_name: "github action: ${{github.workflow}}"
+          fields: repo, ref, commit, author, message

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,7 +11,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: macOS-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PRIVATE_ACTIONS_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
- trying out a new dev version of pkgdown action so that it builds the pkgdown site on the dev branch (but does not push to the gh-pages branch/update our actual website). This allows us to check that it builds properly before we accept and it gets pushed. Current workflow the pkgdown website isn't built until we accept a pull request so we can't check if its broken until its too late.
- adding private repo secrets to fix dependency issue 
