### PR TITLE
Updating saving file path for `sbf_backup_pg`

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -201,7 +201,6 @@ sbf_path_db <- function(x_name = sbf_get_db_name(),
                         ext = "sqlite",
                         exists = NA) {
   chk_string(ext)
-  chk_subset(ext, "sqlite")
   get_path(x_name,
     class = "dbs",
     sub = sub,

--- a/R/pg.R
+++ b/R/pg.R
@@ -20,7 +20,7 @@
 #' sbf_close_pg(conn)
 #' }
 sbf_open_pg <- function(config_path = getOption("psql.config_path", NULL),
-                        config_value = getOption("psql.value", NULL)) {
+                        config_value = getOption("psql.config_value", NULL)) {
   conn <- psql::psql_connect(
     config_path = config_path,
     config_value = config_value
@@ -74,7 +74,7 @@ sbf_backup_pg <- function(db_dump_name = sbf_get_db_name(),
                           sub = sbf_get_sub(),
                           main = sbf_get_main(),
                           config_path = getOption("psql.config_path", NULL),
-                          config_value = getOption("psql.value", NULL)) {
+                          config_value = getOption("psql.config_value", NULL)) {
   path <- file_name(main, "dbs", sub, db_dump_name, ext = "sql")
   psql::psql_backup(
     path = path,
@@ -101,7 +101,7 @@ sbf_backup_pg <- function(db_dump_name = sbf_get_db_name(),
 #' }
 sbf_create_pg <- function(dbname,
                           config_path = getOption("psql.config_path", NULL),
-                          config_value = getOption("psql.value", NULL)) {
+                          config_value = getOption("psql.config_value", NULL)) {
   psql::psql_create_db(
     dbname = dbname,
     config_path = config_path,
@@ -133,7 +133,7 @@ sbf_create_pg <- function(dbname,
 #' }
 sbf_execute_pg <- function(sql,
                            config_path = getOption("psql.config_path", NULL),
-                           config_value = getOption("psql.value", NULL)) {
+                           config_value = getOption("psql.config_value", NULL)) {
   psql::psql_execute_db(
     sql = sql,
     config_path = config_path,
@@ -161,7 +161,7 @@ sbf_execute_pg <- function(sql,
 #' }
 sbf_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
                                config_path = getOption("psql.config_path", NULL),
-                               config_value = getOption("psql.value", NULL)) {
+                               config_value = getOption("psql.config_value", NULL)) {
   psql::psql_list_tables(
     schema = schema,
     config_path = config_path,
@@ -190,7 +190,7 @@ sbf_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
 sbf_load_data_from_pg <- function(x,
                                   schema = getOption("psql.schema", "public"),
                                   config_path = getOption("psql.config_path", NULL),
-                                  config_value = getOption("psql.value", NULL)) {
+                                  config_value = getOption("psql.config_value", NULL)) {
   psql::psql_read_table(
     tbl_name = x,
     schema = schema,
@@ -221,7 +221,7 @@ sbf_load_datas_from_pg <- function(schema = getOption("psql.schema", "public"),
                                    rename = identity,
                                    env = parent.frame(),
                                    config_path = getOption("psql.config_path", NULL),
-                                   config_value = getOption("psql.value", NULL)) {
+                                   config_value = getOption("psql.config_value", NULL)) {
   chk_s3_class(env, "environment")
   chk_function(rename)
 
@@ -267,7 +267,7 @@ sbf_save_data_to_pg <- function(x,
                                 schema = getOption("psql.schema", "public"),
                                 x_name = NULL,
                                 config_path = getOption("psql.config_path", NULL),
-                                config_value = getOption("psql.value", NULL)) {
+                                config_value = getOption("psql.config_value", NULL)) {
   if (is.null(x_name)) x_name <- deparse(substitute(x))
   psql::psql_add_data(
     tbl = x,

--- a/R/pg.R
+++ b/R/pg.R
@@ -56,6 +56,8 @@ sbf_close_pg <- function(conn) {
 #' code to recreate the structure and data.
 #'
 #' @inheritParams psql::psql_backup
+#' @inheritParams sbf_save_object
+#' @param db_dump_name A string of the name for the database backup file
 #'
 #' @return TRUE (or errors)
 #' @export
@@ -64,11 +66,16 @@ sbf_close_pg <- function(conn) {
 #'
 #' @examples
 #' \dontrun{
-#' sbf_backup_pg("/Users/user1/Dumps/dump_db.sql")
+#' sbf_backup_pg()
+#' 
+#' sbf_backup_pg("database-22")
 #' }
-sbf_backup_pg <- function(path = "dump_db.sql",
+sbf_backup_pg <- function(db_dump_name = sbf_get_db_name(),
+                          sub = sbf_get_sub(),
+                          main = sbf_get_main(),
                           config_path = getOption("psql.config_path", NULL),
                           config_value = getOption("psql.value", NULL)) {
+  path <- file_name(main, "dbs", sub, db_dump_name, ext = "sql")
   psql::psql_backup(
     path = path,
     config_path = config_path,

--- a/man/sbf_backup_pg.Rd
+++ b/man/sbf_backup_pg.Rd
@@ -5,13 +5,21 @@
 \title{Save PostgreSQL backup}
 \usage{
 sbf_backup_pg(
-  path = "dump_db.sql",
+  db_dump_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
   config_path = getOption("psql.config_path", NULL),
   config_value = getOption("psql.value", NULL)
 )
 }
 \arguments{
-\item{path}{A string of the file path to save the dumped database}
+\item{db_dump_name}{A string of the name for the database backup file}
+
+\item{sub}{A string specifying the path to the sub folder (by default the
+current sub folder).}
+
+\item{main}{A string specifying the path to the main folder (by default the
+current main folder)}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
 The default value grabs the file path from the psql.config_path option.}
@@ -31,7 +39,9 @@ Wrapper on `psql::psql_backup()`
 }
 \examples{
 \dontrun{
-sbf_backup_pg("/Users/user1/Dumps/dump_db.sql")
+sbf_backup_pg()
+
+sbf_backup_pg("database-22")
 }
 }
 \seealso{

--- a/man/sbf_backup_pg.Rd
+++ b/man/sbf_backup_pg.Rd
@@ -9,7 +9,7 @@ sbf_backup_pg(
   sub = sbf_get_sub(),
   main = sbf_get_main(),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -25,7 +25,7 @@ current main folder)}
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 TRUE (or errors)

--- a/man/sbf_close_pg.Rd
+++ b/man/sbf_close_pg.Rd
@@ -17,8 +17,8 @@ TRUE (or errors).
 Close the PostgreSQL connection when you are done using a database.
 }
 \details{
-Wrapper on `DBI::dbDisconnect()`. It is important to remember to 
-close connections or your database performance can decrease over time.
+Wrapper on `DBI::dbDisconnect()`. It is important to remember to
+  close connections or your database performance can decrease over time.
 }
 \examples{
 \dontrun{

--- a/man/sbf_create_pg.Rd
+++ b/man/sbf_create_pg.Rd
@@ -7,7 +7,7 @@
 sbf_create_pg(
   dbname,
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -17,7 +17,7 @@ sbf_create_pg(
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 TRUE (or errors).

--- a/man/sbf_execute_pg.Rd
+++ b/man/sbf_execute_pg.Rd
@@ -7,7 +7,7 @@
 sbf_execute_pg(
   sql,
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -17,7 +17,7 @@ sbf_execute_pg(
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 A scalar numeric of the number of rows affected by the statement.

--- a/man/sbf_list_tables_pg.Rd
+++ b/man/sbf_list_tables_pg.Rd
@@ -7,7 +7,7 @@
 sbf_list_tables_pg(
   schema = getOption("psql.schema", "public"),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -17,7 +17,7 @@ sbf_list_tables_pg(
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 A vector of table names

--- a/man/sbf_load_data_from_pg.Rd
+++ b/man/sbf_load_data_from_pg.Rd
@@ -8,7 +8,7 @@ sbf_load_data_from_pg(
   x,
   schema = getOption("psql.schema", "public"),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -20,7 +20,7 @@ sbf_load_data_from_pg(
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 A data frame

--- a/man/sbf_load_datas_from_pg.Rd
+++ b/man/sbf_load_datas_from_pg.Rd
@@ -31,8 +31,8 @@ the value from the psql.value option.}
 An invisible character vector of the paths to the saved objects.
 }
 \description{
-Load all the tables in a schema as data frames into your environment from a 
- PostgreSQL database.
+Load all the tables in a schema as data frames into your environment from a
+PostgreSQL database.
 }
 \examples{
 \dontrun{

--- a/man/sbf_load_datas_from_pg.Rd
+++ b/man/sbf_load_datas_from_pg.Rd
@@ -9,7 +9,7 @@ sbf_load_datas_from_pg(
   rename = identity,
   env = parent.frame(),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -25,7 +25,7 @@ Used to rename objects before they are loaded into the environment.}
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 An invisible character vector of the paths to the saved objects.

--- a/man/sbf_open_pg.Rd
+++ b/man/sbf_open_pg.Rd
@@ -6,7 +6,7 @@
 \usage{
 sbf_open_pg(
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -14,7 +14,7 @@ sbf_open_pg(
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 An S4 object that inherits from DBIConnection.

--- a/man/sbf_save_data_to_pg.Rd
+++ b/man/sbf_save_data_to_pg.Rd
@@ -9,7 +9,7 @@ sbf_save_data_to_pg(
   schema = getOption("psql.schema", "public"),
   x_name = NULL,
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.value", NULL)
+  config_value = getOption("psql.config_value", NULL)
 )
 }
 \arguments{
@@ -23,7 +23,7 @@ sbf_save_data_to_pg(
 The default value grabs the file path from the psql.config_path option.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.value option.}
+the value from the psql.config_value option.}
 }
 \value{
 A scalar numeric.

--- a/man/sbf_set_config_file.Rd
+++ b/man/sbf_set_config_file.Rd
@@ -7,7 +7,7 @@
 sbf_set_config_file(path = "config.yml")
 }
 \arguments{
-\item{path}{A file path to the location of the yaml file containing your 
+\item{path}{A file path to the location of the yaml file containing your
 connection details.}
 }
 \value{

--- a/tests/testthat/test-pg.R
+++ b/tests/testthat/test-pg.R
@@ -20,18 +20,18 @@ test_that("test sbf_close_pg works", {
   )
 })
 
-test_that("test sbf_back_pg works", {
+test_that("test sbf_backup_pg works", {
   skip_on_ci()
   # set up
   config_path <- create_local_database()
   temp_dir <- withr::local_tempdir()
-  dump_path <- file.path(temp_dir, "dump_db1.sql")
   # tests
   sbf_backup_pg(
-    path = dump_path,
+    db_dump_name = "dump_db1",
+    main = temp_dir,
     config_path = config_path
   )
-  expect_true(file.exists(dump_path))
+  expect_true(file.exists(file.path(temp_dir, "dbs", "dump_db1.sql")))
 })
 
 test_that("test sbf_create_pg works", {


### PR DESCRIPTION
- updated docs 
- updating `sbf_backup_pg()` to auto create the saving path to be output instead of manually having to write out the file paths
- removed restrictive check in `sbf_path_db()` that conflicted the docs/parameter
- updated psql option from `psql.value` to `psql.config_value` to be more consistent with the other option name