### PR TITLE
correcting default values for pg functions

### DIFF
--- a/R/pg.R
+++ b/R/pg.R
@@ -20,7 +20,7 @@
 #' sbf_close_pg(conn)
 #' }
 sbf_open_pg <- function(config_path = getOption("psql.config_path", NULL),
-                        config_value = getOption("psql.config_value", NULL)) {
+                        config_value = getOption("psql.config_value", "default")) {
   conn <- psql::psql_connect(
     config_path = config_path,
     config_value = config_value
@@ -74,7 +74,7 @@ sbf_backup_pg <- function(db_dump_name = sbf_get_db_name(),
                           sub = sbf_get_sub(),
                           main = sbf_get_main(),
                           config_path = getOption("psql.config_path", NULL),
-                          config_value = getOption("psql.config_value", NULL)) {
+                          config_value = getOption("psql.config_value", "default")) {
   path <- file_name(main, "dbs", sub, db_dump_name, ext = "sql")
   psql::psql_backup(
     path = path,
@@ -101,7 +101,7 @@ sbf_backup_pg <- function(db_dump_name = sbf_get_db_name(),
 #' }
 sbf_create_pg <- function(dbname,
                           config_path = getOption("psql.config_path", NULL),
-                          config_value = getOption("psql.config_value", NULL)) {
+                          config_value = getOption("psql.config_value", "default")) {
   psql::psql_create_db(
     dbname = dbname,
     config_path = config_path,
@@ -133,7 +133,7 @@ sbf_create_pg <- function(dbname,
 #' }
 sbf_execute_pg <- function(sql,
                            config_path = getOption("psql.config_path", NULL),
-                           config_value = getOption("psql.config_value", NULL)) {
+                           config_value = getOption("psql.config_value", "default")) {
   psql::psql_execute_db(
     sql = sql,
     config_path = config_path,
@@ -161,7 +161,7 @@ sbf_execute_pg <- function(sql,
 #' }
 sbf_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
                                config_path = getOption("psql.config_path", NULL),
-                               config_value = getOption("psql.config_value", NULL)) {
+                               config_value = getOption("psql.config_value", "default")) {
   psql::psql_list_tables(
     schema = schema,
     config_path = config_path,
@@ -190,7 +190,7 @@ sbf_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
 sbf_load_data_from_pg <- function(x,
                                   schema = getOption("psql.schema", "public"),
                                   config_path = getOption("psql.config_path", NULL),
-                                  config_value = getOption("psql.config_value", NULL)) {
+                                  config_value = getOption("psql.config_value", "default")) {
   psql::psql_read_table(
     tbl_name = x,
     schema = schema,
@@ -221,7 +221,7 @@ sbf_load_datas_from_pg <- function(schema = getOption("psql.schema", "public"),
                                    rename = identity,
                                    env = parent.frame(),
                                    config_path = getOption("psql.config_path", NULL),
-                                   config_value = getOption("psql.config_value", NULL)) {
+                                   config_value = getOption("psql.config_value", "default")) {
   chk_s3_class(env, "environment")
   chk_function(rename)
 
@@ -267,7 +267,7 @@ sbf_save_data_to_pg <- function(x,
                                 schema = getOption("psql.schema", "public"),
                                 x_name = NULL,
                                 config_path = getOption("psql.config_path", NULL),
-                                config_value = getOption("psql.config_value", NULL)) {
+                                config_value = getOption("psql.config_value", "default")) {
   if (is.null(x_name)) x_name <- deparse(substitute(x))
   psql::psql_add_data(
     tbl = x,
@@ -415,7 +415,7 @@ sbf_set_config_value <- function(value = NULL) {
 #' sbf_get_config_value()
 #' }
 sbf_get_config_value <- function() {
-  getOption("psql.config_value", character(0))
+  getOption("psql.config_value", "default")
 }
 
 #' Reset the Config File Value

--- a/man/sbf_backup_pg.Rd
+++ b/man/sbf_backup_pg.Rd
@@ -9,7 +9,7 @@ sbf_backup_pg(
   sub = sbf_get_sub(),
   main = sbf_get_main(),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/man/sbf_backup_pg.Rd
+++ b/man/sbf_backup_pg.Rd
@@ -22,10 +22,12 @@ current sub folder).}
 current main folder)}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 TRUE (or errors)

--- a/man/sbf_create_pg.Rd
+++ b/man/sbf_create_pg.Rd
@@ -7,7 +7,7 @@
 sbf_create_pg(
   dbname,
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/man/sbf_create_pg.Rd
+++ b/man/sbf_create_pg.Rd
@@ -14,10 +14,12 @@ sbf_create_pg(
 \item{dbname}{A string of the name of the new database to create.}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 TRUE (or errors).

--- a/man/sbf_execute_pg.Rd
+++ b/man/sbf_execute_pg.Rd
@@ -7,7 +7,7 @@
 sbf_execute_pg(
   sql,
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/man/sbf_execute_pg.Rd
+++ b/man/sbf_execute_pg.Rd
@@ -14,10 +14,12 @@ sbf_execute_pg(
 \item{sql}{A string of the SQL statement to execute.}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 A scalar numeric of the number of rows affected by the statement.

--- a/man/sbf_list_tables_pg.Rd
+++ b/man/sbf_list_tables_pg.Rd
@@ -7,7 +7,7 @@
 sbf_list_tables_pg(
   schema = getOption("psql.schema", "public"),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/man/sbf_list_tables_pg.Rd
+++ b/man/sbf_list_tables_pg.Rd
@@ -14,10 +14,12 @@ sbf_list_tables_pg(
 \item{schema}{A string of the schema name. Default value is \code{"public"}.}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 A vector of table names

--- a/man/sbf_load_data_from_pg.Rd
+++ b/man/sbf_load_data_from_pg.Rd
@@ -17,10 +17,12 @@ sbf_load_data_from_pg(
 \item{schema}{A string of the schema name. Default value is \code{"public"}.}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 A data frame

--- a/man/sbf_load_data_from_pg.Rd
+++ b/man/sbf_load_data_from_pg.Rd
@@ -8,7 +8,7 @@ sbf_load_data_from_pg(
   x,
   schema = getOption("psql.schema", "public"),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/man/sbf_load_datas_from_pg.Rd
+++ b/man/sbf_load_datas_from_pg.Rd
@@ -9,7 +9,7 @@ sbf_load_datas_from_pg(
   rename = identity,
   env = parent.frame(),
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/man/sbf_load_datas_from_pg.Rd
+++ b/man/sbf_load_datas_from_pg.Rd
@@ -22,10 +22,12 @@ Used to rename objects before they are loaded into the environment.}
 \item{env}{The environment to  the objects into}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 An invisible character vector of the paths to the saved objects.

--- a/man/sbf_open_pg.Rd
+++ b/man/sbf_open_pg.Rd
@@ -11,10 +11,12 @@ sbf_open_pg(
 }
 \arguments{
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 An S4 object that inherits from DBIConnection.

--- a/man/sbf_open_pg.Rd
+++ b/man/sbf_open_pg.Rd
@@ -6,7 +6,7 @@
 \usage{
 sbf_open_pg(
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/man/sbf_save_data_to_pg.Rd
+++ b/man/sbf_save_data_to_pg.Rd
@@ -20,10 +20,12 @@ sbf_save_data_to_pg(
 \item{x_name}{A string of the name.}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
-The default value grabs the file path from the psql.config_path option.}
+The default value grabs the file path from the psql.config_path option
+and uses \code{NULL} if no value supplied.}
 
 \item{config_value}{A string of the name of value. The default value grabs
-the value from the psql.config_value option.}
+the value from the psql.config_value option and uses \code{"default"} if no
+value is supplied.}
 }
 \value{
 A scalar numeric.

--- a/man/sbf_save_data_to_pg.Rd
+++ b/man/sbf_save_data_to_pg.Rd
@@ -9,7 +9,7 @@ sbf_save_data_to_pg(
   schema = getOption("psql.schema", "public"),
   x_name = NULL,
   config_path = getOption("psql.config_path", NULL),
-  config_value = getOption("psql.config_value", NULL)
+  config_value = getOption("psql.config_value", "default")
 )
 }
 \arguments{

--- a/tests/testthat/test-pg.R
+++ b/tests/testthat/test-pg.R
@@ -3,7 +3,7 @@ test_that("test sbf_open_pg works", {
   # set up
   withr::defer(DBI::dbDisconnect(conn))
   # tests
-  conn <- sbf_open_pg(config_path = NULL, config_value = NULL)
+  conn <- sbf_open_pg(config_path = NULL, config_value = "default")
   expect_s4_class(conn, "PqConnection")
 })
 
@@ -39,7 +39,7 @@ test_that("test sbf_create_pg works", {
   # set up
   clean_up_db("newdb")
   # tests
-  output <- sbf_create_pg("newdb", NULL, NULL)
+  output <- sbf_create_pg("newdb", NULL, "default")
   expect_true(output)
 })
 
@@ -200,5 +200,5 @@ test_that("reset config file value", {
   sbf_set_config_value(value)
   sbf_reset_config_value()
   set_value <- sbf_get_config_value()
-  expect_equal(set_value, character(0))
+  expect_equal(set_value, "default")
 })


### PR DESCRIPTION
- changed the default value of the `config_value` parameter from `NULL` to `"default"` because of how the config files are supposed to be set up when multiple connection parameters are provided.