### PR TITLE
correct parameter order for `sbf_save_data_to_pg()`

### DIFF
--- a/R/pg.R
+++ b/R/pg.R
@@ -264,8 +264,8 @@ sbf_load_datas_from_pg <- function(schema = getOption("psql.schema", "public"),
 #' sbf_save_data_to_pg(outing_new, "creel", "outing")
 #' }
 sbf_save_data_to_pg <- function(x,
-                                schema = getOption("psql.schema", "public"),
                                 x_name = NULL,
+                                schema = getOption("psql.schema", "public"),
                                 config_path = getOption("psql.config_path", NULL),
                                 config_value = getOption("psql.config_value", "default")) {
   if (is.null(x_name)) x_name <- deparse(substitute(x))

--- a/man/sbf_save_data_to_pg.Rd
+++ b/man/sbf_save_data_to_pg.Rd
@@ -6,8 +6,8 @@
 \usage{
 sbf_save_data_to_pg(
   x,
-  schema = getOption("psql.schema", "public"),
   x_name = NULL,
+  schema = getOption("psql.schema", "public"),
   config_path = getOption("psql.config_path", NULL),
   config_value = getOption("psql.config_value", "default")
 )
@@ -15,9 +15,9 @@ sbf_save_data_to_pg(
 \arguments{
 \item{x}{The data frame to save.}
 
-\item{schema}{A string of the schema name. Default value is \code{"public"}.}
-
 \item{x_name}{A string of the name.}
+
+\item{schema}{A string of the schema name. Default value is \code{"public"}.}
 
 \item{config_path}{A string of a file path to the yaml configuration file.
 The default value grabs the file path from the psql.config_path option


### PR DESCRIPTION
Switched the order of the parameters so that the table and then the table name goes before the information that can be pulled from the default set values of `schema`, `config_path` and `config_value` which will most likely not be directly entered into the function as the function can pull those values from the setting functions. 
