### PR TITLE
- Add argument to `sbf_print()` to skip plotting

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -21,12 +21,16 @@ get_err_msg <- function() {
 #' @param newpage	draw new (empty) page first?
 #' @param vp	viewport to draw plot in
 #' @param ntry A positive whole number specifying the number of tries.
+#' @param plot A flag indicating whether or not to print the plot.
 #'
 #' @export
-sbf_print <- function(x, newpage = is.null(vp), vp = NULL, ntry = 3L) {
+sbf_print <- function(x, newpage = is.null(vp), vp = NULL, ntry = 3L, plot = getOption("sbf.plot", TRUE)) {
   chk::chk_is(x, "ggplot")
   chk::chk_whole_number(ntry)
   chk::chk_gt(ntry)
+  chk::chk_flag(plot)
+  
+  if(!plot) return(invisible())
 
   i <- 1
   while (i <= ntry) {

--- a/man/sbf_print.Rd
+++ b/man/sbf_print.Rd
@@ -4,7 +4,13 @@
 \alias{sbf_print}
 \title{Print ggplot Object}
 \usage{
-sbf_print(x, newpage = is.null(vp), vp = NULL, ntry = 3L)
+sbf_print(
+  x,
+  newpage = is.null(vp),
+  vp = NULL,
+  ntry = 3L,
+  plot = getOption("sbf.plot", TRUE)
+)
 }
 \arguments{
 \item{x}{An object to print.}
@@ -14,6 +20,8 @@ sbf_print(x, newpage = is.null(vp), vp = NULL, ntry = 3L)
 \item{vp}{viewport to draw plot in}
 
 \item{ntry}{A positive whole number specifying the number of tries.}
+
+\item{plot}{A flag indicating whether or not to print the plot.}
 }
 \description{
 Retries printing a ggplot object if grid errors occurs.

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -1,0 +1,8 @@
+# sbf_print plot argument errors if not logical
+
+    Code
+      sbf_print(gp, plot = "x")
+    Condition
+      Error in `sbf_print()`:
+      ! `plot` must be a flag (TRUE or FALSE).
+

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -16,3 +16,22 @@ test_that("sbf_print", {
     ggplot2::geom_point()
   expect_identical(sbf_print(gp), gp)
 })
+
+test_that("sbf_print doesn't print if plot = FALSE", {
+  data <- data.frame(x = 1, y = 1)
+  gp <- ggplot2::ggplot(data = data, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_point()
+  
+  expect_identical(sbf_print(gp, plot = FALSE), invisible())
+})
+
+test_that("sbf_print plot argument errors if not logical", {
+  data <- data.frame(x = 1, y = 1)
+  gp <- ggplot2::ggplot(data = data, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_point()
+  
+  expect_snapshot(
+    error = TRUE,
+    sbf_print(gp, plot = "x")
+  )
+})


### PR DESCRIPTION
Closes #101 
This is a workaround for the issues with `sbf_print()` that can cause R to crash, by skipping the printing of plots.
By setting `options(sbf.plot = TRUE)` in the header, no plots will print, but will still be saved as .png files with `sbf_save_plot()`.

See this issue for background: https://github.com/tidyverse/ggplot2/issues/3538