### PR TITLE
- Not ignore_attr

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -12,7 +12,7 @@
 sbf_compare_data <- function(x, x_name = substitute(x),
                              sub = sbf_get_sub(), main = sbf_get_main(),
                              tolerance = sqrt(.Machine$double.eps),
-                             ignore_attr = TRUE) {
+                             ignore_attr = FALSE) {
   rlang::check_installed("waldo")
 
   chk_s3_class(x, "data.frame")
@@ -48,7 +48,7 @@ sbf_compare_data_archive <- function(x_name = ".*", sub = sbf_get_sub(),
                                      recursive = FALSE,
                                      include_root = TRUE,
                                      tolerance = sqrt(.Machine$double.eps),
-                                     ignore_attr = TRUE) {
+                                     ignore_attr = FALSE) {
   rlang::check_installed("waldo")
 
   if (!vld_whole_number(archive) && !vld_dir(archive)) {

--- a/man/sbf_compare_data.Rd
+++ b/man/sbf_compare_data.Rd
@@ -10,7 +10,7 @@ sbf_compare_data(
   sub = sbf_get_sub(),
   main = sbf_get_main(),
   tolerance = sqrt(.Machine$double.eps),
-  ignore_attr = TRUE
+  ignore_attr = FALSE
 )
 }
 \arguments{

--- a/man/sbf_compare_data_archive.Rd
+++ b/man/sbf_compare_data_archive.Rd
@@ -12,7 +12,7 @@ sbf_compare_data_archive(
   recursive = FALSE,
   include_root = TRUE,
   tolerance = sqrt(.Machine$double.eps),
-  ignore_attr = TRUE
+  ignore_attr = FALSE
 )
 }
 \arguments{


### PR DESCRIPTION
From waldo

```
For backward compatibility with all.equal(), you can also use TRUE, to all ignore differences in all attributes. This is not generally recommended as it is a blunt tool that will ignore many important functional differences.
```