### PR TITLE
`sbf_set_main()` no longer errors silently if filepath doesn't exist

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -23,6 +23,7 @@ sbf_set_main <- function(..., rm = FALSE, ask = getOption("sbf.ask", TRUE)) {
   chk_flag(ask)
   path <- file_path(..., collapse = TRUE)
   path <- sanitize_path(path, rm_leading = FALSE)
+  if (!dir.exists(path)) err("The path `", path, "` does not exist.")
   options(sbf.main = path)
   if (rm) rm_all(ask = ask)
   invisible(path)


### PR DESCRIPTION
@sarahLy9 and @joethorley, I've added a single line of code to `sbf_set_main()` so that this function will error and inform the user when the filepath doesn't exist; however, this has caused 10 tests to fail:
```
Backtrace:
    ▆
 1. └─subfoldr2::sbf_reset() at test-copy.R:59:3
 2.   └─subfoldr2::sbf_reset_main() at subfoldr2/R/reset.R:12:3
 3.     └─subfoldr2::sbf_set_main("output", rm = rm, ask = ask) at subfoldr2/R/main.R:40:3
 4.       └─chk::err("The path `", path, "` does not exist.") at subfoldr2/R/main.R:26:3
```
because the "output" path doesn't exist on my computer. Do we want to change `sbf_set_main()` so that it creates a directory if it doesn't exist instead of failing? Or do we want to change `sbf_reset_main()` so that it sets `character(0)` as the default filepath? Something else?

I also tried adding an error message to `sbf_set_sub()` if the filepath doesn't exist, but it didn't work. @joethorley, would you be able to give me a better idea of how these functions work together?

Will resolve #100 when merged and closed.