### PR TITLE
Update Evan Amies-Galonski email and remove Duncan Kennedy email

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0003-1096-2089")),
     person("Nadine", "Hussein", , "nadine@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0003-4470-8361")),
-    person("Duncan", "Kennedy", , "duncan@poissonconsulting.ca", role = "ctb",
+    person("Duncan", "Kennedy", , role = "ctb",
            comment = c(ORCID = "0009-0001-4880-5751")),
     person("Alan", "Constant", role = "ctb"),
     person("Stefano", "Mezzini", , "stefano@poissonconsulting.ca", role = "ctb",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-7683-4592")),
     person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0001-7388-1222")),
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", role = "ctb",
+    person("Evan", "Amies-Galonski", , "evanamiesgalonski@gmail.com", role = "ctb",
            comment = c(ORCID = "0000-0003-1096-2089")),
     person("Nadine", "Hussein", , "nadine@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0003-4470-8361")),


### PR DESCRIPTION
Replaces `evan@poissonconsulting.ca` (no longer an active address) with Evan's personal email `evanamiesgalonski@gmail.com` in DESCRIPTION.