### PR TITLE
- add `drop_uninformative_cols` argument to control whether columns are dropped in the saved csv

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -558,7 +558,7 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
   data <- x$data
   if (is.data.frame(data) && nrow(data) <= csv) {
     if (drop_uninformative_cols) {
-      data <- tidyplus::drop_uninformative_columns(data, )
+      data <- tidyplus::drop_uninformative_columns(data)
     }
     save_csv(data, "plots", sub = sub, main = main, x_name = x_name)
   }

--- a/R/save.R
+++ b/R/save.R
@@ -496,6 +496,9 @@ sbf_save_block <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #' @param dpi A number of the resolution in dots per inch.
 #' @param csv A count specifying the maximum number of rows to save as a csv
 #' file.
+#' @param drop_uninformative_cols A flag indicating whether to drop
+#' uninformative columns via `tidyplus::drop_uninformative_columns()`
+#' (`TRUE`, default) or not (`FALSE`).
 #' @family save functions
 #' @export
 sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
@@ -506,7 +509,8 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
                           units = "in",
                           width = NA, height = width, dpi = 300,
                           limitsize = TRUE,
-                          csv = 1000L) {
+                          csv = 1000L,
+                          drop_uninformative_cols = TRUE) {
   chk_s3_class(x, "ggplot")
   x_name <- chk_deparse(x_name)
   if (identical(x_name, "ggplot2::last_plot()")) {
@@ -531,6 +535,7 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
   chk_gt(dpi)
   chk_whole_number(csv)
   chk_gte(csv)
+  chk_flag(drop_uninformative_cols)
 
   csv <- as.integer(csv)
 
@@ -552,7 +557,9 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
 
   data <- x$data
   if (is.data.frame(data) && nrow(data) <= csv) {
-    data <- tidyplus::drop_uninformative_columns(data)
+    if (drop_uninformative_cols) {
+      data <- tidyplus::drop_uninformative_columns(data, )
+    }
     save_csv(data, "plots", sub = sub, main = main, x_name = x_name)
   }
 

--- a/man/sbf_save_plot.Rd
+++ b/man/sbf_save_plot.Rd
@@ -17,7 +17,8 @@ sbf_save_plot(
   height = width,
   dpi = 300,
   limitsize = TRUE,
-  csv = 1000L
+  csv = 1000L,
+  drop_uninformative_cols = TRUE
 )
 }
 \arguments{
@@ -51,6 +52,10 @@ specifying dimensions in pixels.}
 
 \item{csv}{A count specifying the maximum number of rows to save as a csv
 file.}
+
+\item{drop_uninformative_cols}{A flag indicating whether to drop
+uninformative columns via \code{tidyplus::drop_uninformative_columns()}
+(\code{TRUE}, default) or not (\code{FALSE}).}
 }
 \description{
 Saves a ggplot object.

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -897,7 +897,8 @@ test_that("plot", {
   )
   
   x <- ggplot2::ggplot()
-  expect_identical(sbf_save_plot(x), file.path(sbf_get_main(), "plots/x.rds"))
+  expect_identical(sbf_save_plot(x, drop_uninformative_cols = TRUE),
+                   file.path(sbf_get_main(), "plots/x.rds"))
   expect_true(all.equal(sbf_load_plot("x"), x))
   expect_identical(sbf_load_plot_data("x"), data.frame())
   
@@ -905,14 +906,23 @@ test_that("plot", {
   expect_false(file.exists(file.path(sbf_get_main(), "plots/x2.rds")))
   
   y <- ggplot2::ggplot(
-    data = data.frame(x = 1, y = 2),
+    data = data.frame(x = 1:3, y = 2:4, z = NA_real_),
     ggplot2::aes(x = x, y = y)
   )
+  expect_identical(sbf_save_plot(y, drop_uninformative_cols = FALSE),
+                   file.path(sbf_get_main(), "plots/y.rds"))
+  expect_identical(read.csv(paste0(sbf_get_main(), "/plots/y.csv")),
+                   data.frame(x = 1:3, y = 2:4, z = NA))
+  
   expect_identical(sbf_save_plot(y), file.path(sbf_get_main(), "plots/y.rds"))
   
   expect_true(all.equal(sbf_load_plot("y"), y))
   
-  expect_identical(sbf_load_plot_data("y"), data.frame(x = 1, y = 2))
+  expect_identical(sbf_load_plot_data("y"),
+                   data.frame(x = 1:3, y = 2:4, z = NA_real_))
+  
+  expect_identical(read.csv(paste0(sbf_get_main(), "/plots/y.csv")),
+                   data.frame(x = 1:3, y = 2:4))
   
   expect_identical(
     list.files(file.path(sbf_get_main(), "plots")),
@@ -924,7 +934,7 @@ test_that("plot", {
   
   expect_identical(sbf_load_plots_data(), c("x", "y"))
   expect_identical(x, data.frame())
-  expect_identical(y, data.frame(x = 1, y = 2))
+  expect_identical(y, data.frame(x = 1:3, y = 2:4, z = NA_real_))
   
   z <- ggplot2::ggplot(
     data = data.frame(x = 2, y = 3),

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -906,6 +906,15 @@ test_that("plot", {
   expect_false(file.exists(file.path(sbf_get_main(), "plots/x2.rds")))
   
   y <- ggplot2::ggplot(
+    data = data.frame(x = 1, y = 2, z = NA_real_),
+    ggplot2::aes(x = x, y = y)
+  )
+  expect_identical(sbf_save_plot(y, drop_uninformative_cols = TRUE),
+                   file.path(sbf_get_main(), "plots/y.rds"))
+  expect_error(read.csv(paste0(sbf_get_main(), "/plots/y.csv")),
+               "no lines available in input")
+  
+  y <- ggplot2::ggplot(
     data = data.frame(x = 1:3, y = 2:4, z = NA_real_),
     ggplot2::aes(x = x, y = y)
   )


### PR DESCRIPTION
Something worth noting is that single-row datasets aren't currently considered to have any informative columns, although that's a `{tidyplus}` problem.

I've:

* added the `drop_uninformative_cols` argument for controlling the dropping of columns in the csv saved by `sbf_save_plot()`
* expanded tests to test the `drop_uninformative_cols` argument. I had to make the `y` dataset have > 1 row for the test to work.