### PR TITLE
require `{ggplot2} >= 4.0.0`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     DBI,
     dttr2,
     fs,
-    ggplot2,
+    ggplot2 (>= 4.0.0),
     graphics,
     grDevices,
     hms,


### PR DESCRIPTION
requiring now that ggplot >= 4.0.0 is using S7 objects