### PR TITLE
Clean up sbf_save_plot() layer/patch dataset saving

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -521,7 +521,7 @@ unstitch_patches <- function(x) {
 # Named list (one element) of the data passed to `ggplot()` for a single plot,
 # or an empty list when there is no informative data frame. The sheet is named
 # "<prefix>_0_data".
-plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
+get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
   data <- p@data
   if (!is.data.frame(data)) {
     return(list())
@@ -538,7 +538,7 @@ plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
 # Named list of the data for each geom layer of a single plot, named
 # "<prefix>_<layer>_<geom>". Layers whose data is not a data frame or exceeds
 # `csv` rows are returned as `NULL` and dropped by the caller.
-plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
+get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
   n_layers <- length(p@layers)
   if (!n_layers) {
     return(list())
@@ -702,8 +702,8 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
 
   sheet_list <- purrr::imap(plot_list, function(p, i) {
     c(
-      plot_data_sheet(p, i, drop_uninformative_cols),
-      plot_layer_sheets(p, i, csv, drop_uninformative_cols)
+      get_plot_data_sheet(p, i, drop_uninformative_cols),
+      get_plot_layer_sheets(p, i, csv, drop_uninformative_cols)
     )
   })
   sheet_list <- purrr::compact(purrr::list_flatten(sheet_list))

--- a/R/save.R
+++ b/R/save.R
@@ -503,7 +503,7 @@ sbf_save_block <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #'   length(subfoldr2:::unstitch_patches(pw))
 #' }
 unstitch_patches <- function(x) {
-  chk_s3_class(x, "ggplot")
+  chk_s3_class(x, "ggplot") # update to S7 check once available in {chk}
   if (!inherits(x, "patchwork")) {
     return(x)
   }

--- a/R/save.R
+++ b/R/save.R
@@ -585,7 +585,7 @@ get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
 #' 2. An `rda` file of the plot metadata.
 #' 3. An `rds` file of the plot.
 #' 4. A `csv` of the data passed to `ggplot()`, provided it has at least one row
-#' and no more than `csv` rows. If `x` is a `{patchwork}` object, only the data
+#' and no more than `csv` rows. If `x` is a `patchwork` object, only the data
 #' for the first patch is saved, to maintain compatibility with previous
 #' versions.
 #' 5. An `xlsx` workbook with a sheet for the data passed to each `ggplot()`

--- a/R/save.R
+++ b/R/save.R
@@ -496,32 +496,68 @@ sbf_save_block <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #'
 #' @keywords internal
 #' @examples
-#' require(ggplot2)
-#' require(patchwork)
-#' p <- ggplot()
-#' p_patches <-
-#'   ((ggplot() + ggtitle("1")) + (ggplot() + ggtitle("2"))) /
-#'   ((ggplot() + ggtitle("3")) +
-#'      ((ggplot() + ggtitle("4")) + ggplot() + ggtitle("5")))
-#' p_patches
-#' l <- subfoldr2:::unstitch_patches(p_patches)
-#' do.call(patchwork::wrap_plots, sample(l, size = 5, replace = FALSE))
+#' p <- ggplot2::ggplot() + ggplot2::ggtitle("1")
+#' # combine into a patchwork then split it back into its individual plots
+#' if (requireNamespace("patchwork", quietly = TRUE)) {
+#'   pw <- patchwork::wrap_plots(p, p)
+#'   length(subfoldr2:::unstitch_patches(pw))
+#' }
 unstitch_patches <- function(x) {
-  chk_true(inherits(x, "ggplot"))
-  if (! inherits(x, "patchwork")) {
+  chk_s3_class(x, "ggplot")
+  if (!inherits(x, "patchwork")) {
     return(x)
-  } else {
-    plot_list <- list()
-    
-    for (i in 1:length(x)) {
-      if (inherits(x[[i]], "patchwork")) {
-        plot_list <- c(plot_list, unstitch_patches(x[[i]]))
-      } else {
-        plot_list <- c(plot_list, list(x[[i]]))
-      }
-    }
-    return(plot_list)
   }
+  plot_list <- list()
+  for (i in seq_along(x)) {
+    if (inherits(x[[i]], "patchwork")) {
+      plot_list <- c(plot_list, unstitch_patches(x[[i]]))
+    } else {
+      plot_list <- c(plot_list, list(x[[i]]))
+    }
+  }
+  plot_list
+}
+
+# Named list (one element) of the data passed to `ggplot()` for a single plot,
+# or an empty list when there is no informative data frame. The sheet is named
+# "<prefix>_0_data".
+plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
+  data <- p@data
+  if (!is.data.frame(data)) {
+    return(list())
+  }
+  if (drop_uninformative_cols) {
+    data <- tidyplus::drop_uninformative_columns(data)
+  }
+  if (!nrow(data) || !ncol(data)) {
+    return(list())
+  }
+  stats::setNames(list(data), paste0(prefix, "_0_data"))
+}
+
+# Named list of the data for each geom layer of a single plot, named
+# "<prefix>_<layer>_<geom>". Layers whose data is not a data frame or exceeds
+# `csv` rows are returned as `NULL` and dropped by the caller.
+plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
+  n_layers <- length(p@layers)
+  if (!n_layers) {
+    return(list())
+  }
+  sheets <- purrr::map(seq_len(n_layers), function(layer) {
+    data <- ggplot2::layer_data(p, i = layer)
+    if (!is.data.frame(data) || nrow(data) > csv) {
+      return(NULL)
+    }
+    if (drop_uninformative_cols) {
+      data <- tidyplus::drop_uninformative_columns(data)
+    }
+    data
+  })
+  names(sheets) <- purrr::map_chr(seq_len(n_layers), function(layer) {
+    geom <- tolower(gsub("Geom", "", class(p@layers[[layer]]$geom)[1]))
+    paste0(prefix, "_", layer, "_", geom)
+  })
+  sheets
 }
 
 #' Save Plot
@@ -543,25 +579,24 @@ unstitch_patches <- function(x) {
 #' uninformative columns via `tidyplus::drop_uninformative_columns()`
 #' (`TRUE`, default) or not (`FALSE`).
 #' @details
-#' {The function saves:
-#' 
-#' 1. A `png` file of the plot
-#' 2. An `rda` file of the plot metadata
-#' 3. An `rds` file of the plot
-#' 4. A `csv` of the data passed to `ggplot()` (as long as `nrow(x@data) > 1`).
-#' If `x` is a patchwork object, only the data for the first patch is saved
-#' to maintain compatibility with previous versions.
-#' 5. An `xlsx` workbook for the data passed each `ggplot()` call and each
-#' layer in the related plot.
-#' Sheets are labelled `<p>_<l>_<geom>`, where `<p>` is the row-wise patch
-#' index (1 if `x` is a simple `ggplot` plot), `<l>` is the layer index,
-#' and `<geom>` is the layer type (e.g., `point`, `line`).
-#' 
-#' `csv` and `xlsx` files are named using the `x_name` argument.
-#' Note that not specifying `x` will overwrite existing files that used
-#' `x_name = "plot"`.
-#' }
-#' 
+#' The function saves:
+#'
+#' 1. A `png` file of the plot.
+#' 2. An `rda` file of the plot metadata.
+#' 3. An `rds` file of the plot.
+#' 4. A `csv` of the data passed to `ggplot()`, provided it has at least one row
+#' and no more than `csv` rows. If `x` is a `{patchwork}` object, only the data
+#' for the first patch is saved, to maintain compatibility with previous
+#' versions.
+#' 5. An `xlsx` workbook with a sheet for the data passed to each `ggplot()`
+#' call and a sheet for each geom layer. Sheets are labelled `<p>_<l>_<geom>`,
+#' where `<p>` is the patch index (1 for a simple `ggplot`), `<l>` is the layer
+#' index (`0` for the `ggplot()` data), and `<geom>` is the layer type (e.g.
+#' `point`, `line`). Layers with more than `csv` rows are omitted.
+#'
+#' The `csv` and `xlsx` files are named using the `x_name` argument. Not
+#' specifying `x` overwrites existing files that used `x_name = "plot"`.
+#'
 #' @family save functions
 #' @export
 #' @examples
@@ -648,118 +683,34 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
     dpi = dpi
   )
   save_meta(meta, "plots", sub = sub, main = main, x_name = x_name)
-  
-  if (inherits(x, "patchwork")) {
-    plot_list <- unstitch_patches(x)
-    
-    # only first plot is saved as csv to maintain previous functionality
-    main_data_1 <- plot_list[[1]]@data
-    if (is.data.frame(main_data_1) && nrow(main_data_1) && nrow(main_data_1)) {
-      if (drop_uninformative_cols) {
-        main_data_1 <- tidyplus::drop_uninformative_columns(main_data_1)
-      }
-      
-      if (ncol(main_data_1) <= csv) {
-        save_csv(x = main_data_1, class = "plots", sub = sub, main = main,
-                 x_name = x_name)
-      }
+
+  # patchwork plots are split into their individual plots; a simple ggplot is
+  # treated as a single-element list. Note that cowplot::plot_grid() has no
+  # distinguishing class and is not supported; use {patchwork} instead.
+  plot_list <- if (inherits(x, "patchwork")) unstitch_patches(x) else list(x)
+
+  # only the first plot's data is saved as a csv, to maintain previous behaviour
+  data <- plot_list[[1]]@data
+  if (is.data.frame(data)) {
+    if (drop_uninformative_cols) {
+      data <- tidyplus::drop_uninformative_columns(data)
     }
-    
-    sheet_list <- list(data = NULL)
-    
-    purrr::imap(plot_list, function(.p, .i) {
-      .x_name <- paste0(x_name, "_", .i)
-      mapping <- NULL # to avoid note during R CMD check on mapping not existing
-      .sheet_list <- list(data = NULL)
-      layers <- dplyr::filter(ggplot2::summarise_layers(ggplot2::ggplot_build(x)),
-                              purrr::map_int(mapping, length) > 0)
-      n_layers <- length(.p@layers)
-      
-      main_data <- .p@data
-      
-      if (is.data.frame(main_data)) {
-        if (drop_uninformative_cols) {
-          main_data <- tidyplus::drop_uninformative_columns(main_data)
-        }
-        .sheet_list[1] <- list(data = main_data)
-        names(.sheet_list)[length(.sheet_list)] <- paste0(.i, "_0_data")
-      }
-      
-      if (n_layers) {
-        .sheet_list[(1:n_layers) + length(.sheet_list)] <-
-          purrr::map(1:n_layers, function(layer_index) {
-            data <- ggplot2::layer_data(.p, i = layer_index)
-            if (is.data.frame(data) && nrow(data) <= csv) {
-              if (drop_uninformative_cols) {
-                data <- tidyplus::drop_uninformative_columns(data)
-              }
-              data
-            } else {
-              NULL
-            }
-          })
-      }
-      names(.sheet_list) <- c(
-        paste0(.i, "_0_data"),
-        purrr::map_chr(1:n_layers, function(layer_index) {
-          name <- class(.p@layers[[layer_index]]$geom)[1]
-          name <- gsub("Geom", "", name)
-          name <- paste0(.i, "_", layer_index, "_", tolower(name))
-        }))
-      sheet_list <<- c(sheet_list, .sheet_list)
-    })
-  } else { # assumed to be regular ggplot2 plot (see note below)
-    # note: cowplot::plot_grid() does not have specific classes!
-    # use {patchwork} instead
-    mapping <- NULL # to avoid note during R CMD check on mapping not existing
-    sheet_list <- list(data = NULL)
-    layers <- dplyr::filter(ggplot2::summarise_layers(ggplot2::ggplot_build(x)),
-                            purrr::map_int(mapping, length) > 0)
-    n_layers <- length(x@layers)
-    
-    main_data <- x@data
-    if (is.data.frame(main_data)) {
-      if (drop_uninformative_cols) {
-        main_data <- tidyplus::drop_uninformative_columns(main_data)
-      }
-      
-      if (nrow(main_data) && ncol(main_data)) {
-        if (nrow(main_data) <= csv) {
-          save_csv(x = main_data, class = "plots", sub = sub, main = main,
-                   x_name = x_name)
-        }
-        sheet_list[1] <- list(data = main_data)
-      }
-    }
-    
-    if (n_layers) {
-      sheet_list[(1:n_layers) + length(sheet_list)] <-
-        purrr::map(1:n_layers, function(layer_index) {
-          data <- ggplot2::layer_data(x, i = layer_index)
-          if (is.data.frame(data) && nrow(data) <= csv) {
-            if (drop_uninformative_cols) {
-              data <- tidyplus::drop_uninformative_columns(data)
-            }
-            data
-          } else {
-            NULL
-          }
-        })
-      names(sheet_list) <- c(
-        "1_0_data",
-        purrr::map_chr(1:n_layers, function(layer_index) {
-          name <- class(x@layers[[layer_index]]$geom)[1]
-          name <- gsub("Geom", "", name)
-          name <- paste0("1_", layer_index, "_", tolower(name))
-        }))
+    if (nrow(data) && ncol(data) && nrow(data) <= csv) {
+      save_csv(data, "plots", sub = sub, main = main, x_name = x_name)
     }
   }
-  
-  sheet_list <- sheet_list[!purrr::map_lgl(sheet_list, is.null)]
+
+  sheet_list <- purrr::imap(plot_list, function(p, i) {
+    c(
+      plot_data_sheet(p, i, drop_uninformative_cols),
+      plot_layer_sheets(p, i, csv, drop_uninformative_cols)
+    )
+  })
+  sheet_list <- purrr::compact(purrr::list_flatten(sheet_list))
   if (length(sheet_list)) {
     save_xlsx(sheet_list, "plots", sub = sub, main = main, x_name = x_name)
   }
-  
+
   save_rds(x, "plots", sub = sub, main = main, x_name = x_name)
 }
 

--- a/man/sbf_save_plot.Rd
+++ b/man/sbf_save_plot.Rd
@@ -62,25 +62,24 @@ Saves a ggplot object.
 By default it saves the last plot to be modified or created.
 }
 \details{
-{The function saves:
+The function saves:
 \enumerate{
-\item A \code{png} file of the plot
-\item An \code{rda} file of the plot metadata
-\item An \code{rds} file of the plot
-\item A \code{csv} of the data passed to \code{ggplot()} (as long as \code{nrow(x@data) > 1}).
-If \code{x} is a patchwork object, only the data for the first patch is saved
-to maintain compatibility with previous versions.
-\item An \code{xlsx} workbook for the data passed each \code{ggplot()} call and each
-layer in the related plot.
-Sheets are labelled \verb{<p>_<l>_<geom>}, where \verb{<p>} is the row-wise patch
-index (1 if \code{x} is a simple \code{ggplot} plot), \verb{<l>} is the layer index,
-and \verb{<geom>} is the layer type (e.g., \code{point}, \code{line}).
+\item A \code{png} file of the plot.
+\item An \code{rda} file of the plot metadata.
+\item An \code{rds} file of the plot.
+\item A \code{csv} of the data passed to \code{ggplot()}, provided it has at least one row
+and no more than \code{csv} rows. If \code{x} is a \code{{patchwork}} object, only the data
+for the first patch is saved, to maintain compatibility with previous
+versions.
+\item An \code{xlsx} workbook with a sheet for the data passed to each \code{ggplot()}
+call and a sheet for each geom layer. Sheets are labelled \verb{<p>_<l>_<geom>},
+where \verb{<p>} is the patch index (1 for a simple \code{ggplot}), \verb{<l>} is the layer
+index (\code{0} for the \code{ggplot()} data), and \verb{<geom>} is the layer type (e.g.
+\code{point}, \code{line}). Layers with more than \code{csv} rows are omitted.
 }
 
-\code{csv} and \code{xlsx} files are named using the \code{x_name} argument.
-Note that not specifying \code{x} will overwrite existing files that used
-\code{x_name = "plot"}.
-}
+The \code{csv} and \code{xlsx} files are named using the \code{x_name} argument. Not
+specifying \code{x} overwrites existing files that used \code{x_name = "plot"}.
 }
 \examples{
 \dontrun{

--- a/man/sbf_save_plot.Rd
+++ b/man/sbf_save_plot.Rd
@@ -68,7 +68,7 @@ The function saves:
 \item An \code{rda} file of the plot metadata.
 \item An \code{rds} file of the plot.
 \item A \code{csv} of the data passed to \code{ggplot()}, provided it has at least one row
-and no more than \code{csv} rows. If \code{x} is a \code{{patchwork}} object, only the data
+and no more than \code{csv} rows. If \code{x} is a \code{patchwork} object, only the data
 for the first patch is saved, to maintain compatibility with previous
 versions.
 \item An \code{xlsx} workbook with a sheet for the data passed to each \code{ggplot()}

--- a/man/unstitch_patches.Rd
+++ b/man/unstitch_patches.Rd
@@ -20,15 +20,11 @@ If \code{x} is a \code{ggplot} object but not a \code{patchwork} object, it is s
 returned.
 }
 \examples{
-require(ggplot2)
-require(patchwork)
-p <- ggplot()
-p_patches <-
-  ((ggplot() + ggtitle("1")) + (ggplot() + ggtitle("2"))) /
-  ((ggplot() + ggtitle("3")) +
-     ((ggplot() + ggtitle("4")) + ggplot() + ggtitle("5")))
-p_patches
-l <- subfoldr2:::unstitch_patches(p_patches)
-do.call(patchwork::wrap_plots, sample(l, size = 5, replace = FALSE))
+p <- ggplot2::ggplot() + ggplot2::ggtitle("1")
+# combine into a patchwork then split it back into its individual plots
+if (requireNamespace("patchwork", quietly = TRUE)) {
+  pw <- patchwork::wrap_plots(p, p)
+  length(subfoldr2:::unstitch_patches(pw))
+}
 }
 \keyword{internal}

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -944,7 +944,7 @@ test_that("plot", {
   expect_identical(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "y.xlsx")),
                    dplyr::tibble(x = as.numeric(1:3), y = as.numeric(2:4)))
   expect_identical(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "y.xlsx")),
-                   "data")
+                   "1_0_data")
 
   expect_identical(sbf_load_plots_data(), c("x", "y"))
   expect_identical(x, data.frame())


### PR DESCRIPTION
Targets `issue151` (PR #157) to review and clean up the layer/patch dataset saving, with no intended change in behaviour except one sheet-name normalisation.

## Changes

- **Remove dead code.** The `layers <- dplyr::filter(summarise_layers(ggplot_build(...)), ...)` block (plus the `mapping <- NULL` R CMD check work-around) was computed in both branches but never used, and in the patchwork branch it built from `x` rather than the current patch. The unused `.x_name` was also dropped.
- **De-duplicate.** The two near-identical branches are replaced by `plot_data_sheet()` and `plot_layer_sheets()` helpers shared by both paths, driven by a single `purrr::imap()` over the plot list (a simple ggplot is treated as a one-element list).
- **Fix latent bugs in the patchwork csv branch:** a duplicated guard `nrow(main_data_1) && nrow(main_data_1)`, and `ncol(main_data_1) <= csv` where `csv` is a maximum *row* count (the simple-ggplot branch already used `nrow`).
- **Normalise sheet naming.** The `ggplot()` data sheet is now always named `<patch>_0_data`; previously a simple plot with data but no layers named it `"data"`. The corresponding test assertion is updated. (No package code reads sheets back by name.)
- **Tidy-ups:** `seq_along()`/`seq_len()` instead of `1:length()`; clearer `@details` (removed stray literal braces, corrected the row condition); `unstitch_patches()` example made deterministic and guarded with `requireNamespace("patchwork")`.

## Verification

`devtools::document()` regenerated the Rd files; `test-save-load.R` passes (only the usual on-CRAN / screen-device skips). The existing `p_layers` and `p_patches` tests are unchanged and continue to pass.

Opened as a draft against the PR branch; merge into #157 if it looks right.