### PR TITLE
- removed `drop-uninformative-cols` argument

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -522,9 +522,6 @@ unstitch_patches <- function(x) {
 # or an empty list when there is no informative data frame. The sheet is named
 # "<prefix>_0_data".
 get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
-  if(!missing(drop_uninformative_cols)) {
-    lifecycle::deprecate_warn("VERSION", "get_plot_data_sheet(drop_uninformative_cols)")
-  }
   chk_flag(drop_uninformative_cols)
   
   data <- p@data
@@ -544,9 +541,6 @@ get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
 # "<prefix>_<layer>_<geom>". Layers whose data is not a data frame or exceeds
 # `csv` rows are returned as `NULL` and dropped by the caller.
 get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
-  if(!missing(drop_uninformative_cols)) {
-    lifecycle::deprecate_warn("VERSION", "get_plot_layer_sheets(drop_uninformative_cols)")
-  }
   chk_flag(drop_uninformative_cols)
   
   n_layers <- length(p@layers)

--- a/R/save.R
+++ b/R/save.R
@@ -522,8 +522,6 @@ unstitch_patches <- function(x) {
 # or an empty list when there is no informative data frame. The sheet is named
 # "<prefix>_0_data".
 get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
-  chk_flag(drop_uninformative_cols)
-  
   data <- p@data
   if (!is.data.frame(data)) {
     return(list())
@@ -541,8 +539,6 @@ get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
 # "<prefix>_<layer>_<geom>". Layers whose data is not a data frame or exceeds
 # `csv` rows are returned as `NULL` and dropped by the caller.
 get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
-  chk_flag(drop_uninformative_cols)
-  
   n_layers <- length(p@layers)
   if (!n_layers) {
     return(list())

--- a/R/save.R
+++ b/R/save.R
@@ -1,4 +1,3 @@
-# FIXME: confirmation messages on refusal
 file_name <- function(main, class, sub, x_name, ext) {
   dir <- file_path(main, class, sub)
   dir_create(dir)

--- a/R/save.R
+++ b/R/save.R
@@ -648,7 +648,7 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
                           csv = 1000L,
                           drop_uninformative_cols = TRUE) {
   if(!missing(drop_uninformative_cols)) {
-    lifecycle::deprecate_warn("VERSION", "sbf_save_plot(drop_uninformative_cols)")
+    lifecycle::deprecate_warn("1.0.1.9010", "sbf_save_plot(drop_uninformative_cols)")
   }
   
   chk_s3_class(x, "ggplot")

--- a/R/save.R
+++ b/R/save.R
@@ -1,3 +1,4 @@
+# FIXME: confirmation messages on refusal
 file_name <- function(main, class, sub, x_name, ext) {
   dir <- file_path(main, class, sub)
   dir_create(dir)
@@ -521,10 +522,18 @@ unstitch_patches <- function(x) {
 # Named list (one element) of the data passed to `ggplot()` for a single plot,
 # or an empty list when there is no informative data frame. The sheet is named
 # "<prefix>_0_data".
-get_plot_data_sheet <- function(p, prefix) {
+get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
+  if(!missing(drop_uninformative_cols)) {
+    lifecycle::deprecate_warn("VERSION", "get_plot_data_sheet(drop_uninformative_cols)")
+  }
+  chk_flag(drop_uninformative_cols)
+  
   data <- p@data
   if (!is.data.frame(data)) {
     return(list())
+  }
+  if (drop_uninformative_cols) {
+    data <- tidyplus::drop_uninformative_columns(data)
   }
   if (!nrow(data) || !ncol(data)) {
     return(list())
@@ -535,7 +544,12 @@ get_plot_data_sheet <- function(p, prefix) {
 # Named list of the data for each geom layer of a single plot, named
 # "<prefix>_<layer>_<geom>". Layers whose data is not a data frame or exceeds
 # `csv` rows are returned as `NULL` and dropped by the caller.
-get_plot_layer_sheets <- function(p, prefix, csv) {
+get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
+  if(!missing(drop_uninformative_cols)) {
+    lifecycle::deprecate_warn("VERSION", "get_plot_layer_sheets(drop_uninformative_cols)")
+  }
+  chk_flag(drop_uninformative_cols)
+  
   n_layers <- length(p@layers)
   if (!n_layers) {
     return(list())
@@ -544,6 +558,9 @@ get_plot_layer_sheets <- function(p, prefix, csv) {
     data <- ggplot2::layer_data(p, i = layer)
     if (!is.data.frame(data) || nrow(data) > csv) {
       return(NULL)
+    }
+    if (drop_uninformative_cols) {
+      data <- tidyplus::drop_uninformative_columns(data)
     }
     data
   })
@@ -569,6 +586,12 @@ get_plot_layer_sheets <- function(p, prefix, csv) {
 #' @param dpi A number of the resolution in dots per inch.
 #' @param csv A count specifying the maximum number of rows to save as a csv
 #' file.
+#' @param drop_uninformative_cols A flag indicating whether to drop
+#' uninformative columns via `tidyplus::drop_uninformative_columns()`
+#' (`TRUE`; default) or not (`FALSE`).
+#' Currently soft-deprecated.
+#' Will be fully deprecated in future versions so that uninformative columns are
+#' always dropped in csv files and always kept in xlsx files.
 #' @details
 #' The function saves:
 #'
@@ -579,8 +602,6 @@ get_plot_layer_sheets <- function(p, prefix, csv) {
 #' and no more than `csv` rows. If `x` is a `patchwork` object, only the data
 #' for the first patch is saved, to maintain compatibility with previous
 #' versions.
-#' Uninformative columns are dropped via `tidyplus::drop_uninformative_columns()`
-#' using default arguments.
 #' 5. An `xlsx` workbook with a sheet for the data passed to each `ggplot()`
 #' call and a sheet for each geom layer. Sheets are labelled `<p>_<l>_<geom>`,
 #' where `<p>` is the patch index (1 for a simple `ggplot`), `<l>` is the layer
@@ -631,7 +652,12 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
                           units = "in",
                           width = NA, height = width, dpi = 300,
                           limitsize = TRUE,
-                          csv = 1000L) {
+                          csv = 1000L,
+                          drop_uninformative_cols = TRUE) {
+  if(!missing(drop_uninformative_cols)) {
+    lifecycle::deprecate_warn("VERSION", "sbf_save_plot(drop_uninformative_cols)")
+  }
+  
   chk_s3_class(x, "ggplot")
   x_name <- chk_deparse(x_name)
   if (identical(x_name, "ggplot2::last_plot()")) {
@@ -648,6 +674,7 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
   chk_string(tag)
   chk_string(units)
   chk_subset(units, c("in", "mm", "cm"))
+  chk_flag(drop_uninformative_cols)
 
   sub <- sanitize_path(sub)
   main <- sanitize_path(main, rm_leading = FALSE)
@@ -683,16 +710,18 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
   # only the first plot's data is saved as a csv, to maintain previous behaviour
   data <- plot_list[[1]]@data
   if (is.data.frame(data)) {
+    if (drop_uninformative_cols) {
+      data <- tidyplus::drop_uninformative_columns(data)
+    }
     if (nrow(data) && ncol(data) && nrow(data) <= csv) {
-      save_csv(tidyplus::drop_uninformative_columns(data),
-               "plots", sub = sub, main = main, x_name = x_name)
+      save_csv(data, "plots", sub = sub, main = main, x_name = x_name)
     }
   }
 
   sheet_list <- purrr::imap(plot_list, function(p, i) {
     c(
-      get_plot_data_sheet(p, i),
-      get_plot_layer_sheets(p, i, csv)
+      get_plot_data_sheet(p, i, drop_uninformative_cols),
+      get_plot_layer_sheets(p, i, csv, drop_uninformative_cols)
     )
   })
   sheet_list <- purrr::compact(purrr::list_flatten(sheet_list))

--- a/R/save.R
+++ b/R/save.R
@@ -521,13 +521,10 @@ unstitch_patches <- function(x) {
 # Named list (one element) of the data passed to `ggplot()` for a single plot,
 # or an empty list when there is no informative data frame. The sheet is named
 # "<prefix>_0_data".
-get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
+get_plot_data_sheet <- function(p, prefix) {
   data <- p@data
   if (!is.data.frame(data)) {
     return(list())
-  }
-  if (drop_uninformative_cols) {
-    data <- tidyplus::drop_uninformative_columns(data)
   }
   if (!nrow(data) || !ncol(data)) {
     return(list())
@@ -538,7 +535,7 @@ get_plot_data_sheet <- function(p, prefix, drop_uninformative_cols) {
 # Named list of the data for each geom layer of a single plot, named
 # "<prefix>_<layer>_<geom>". Layers whose data is not a data frame or exceeds
 # `csv` rows are returned as `NULL` and dropped by the caller.
-get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
+get_plot_layer_sheets <- function(p, prefix, csv) {
   n_layers <- length(p@layers)
   if (!n_layers) {
     return(list())
@@ -547,9 +544,6 @@ get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
     data <- ggplot2::layer_data(p, i = layer)
     if (!is.data.frame(data) || nrow(data) > csv) {
       return(NULL)
-    }
-    if (drop_uninformative_cols) {
-      data <- tidyplus::drop_uninformative_columns(data)
     }
     data
   })
@@ -575,9 +569,6 @@ get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
 #' @param dpi A number of the resolution in dots per inch.
 #' @param csv A count specifying the maximum number of rows to save as a csv
 #' file.
-#' @param drop_uninformative_cols A flag indicating whether to drop
-#' uninformative columns via `tidyplus::drop_uninformative_columns()`
-#' (`TRUE`, default) or not (`FALSE`).
 #' @details
 #' The function saves:
 #'
@@ -588,6 +579,8 @@ get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
 #' and no more than `csv` rows. If `x` is a `patchwork` object, only the data
 #' for the first patch is saved, to maintain compatibility with previous
 #' versions.
+#' Uninformative columns are dropped via `tidyplus::drop_uninformative_columns()`
+#' using default arguments.
 #' 5. An `xlsx` workbook with a sheet for the data passed to each `ggplot()`
 #' call and a sheet for each geom layer. Sheets are labelled `<p>_<l>_<geom>`,
 #' where `<p>` is the patch index (1 for a simple `ggplot`), `<l>` is the layer
@@ -638,8 +631,7 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
                           units = "in",
                           width = NA, height = width, dpi = 300,
                           limitsize = TRUE,
-                          csv = 1000L,
-                          drop_uninformative_cols = TRUE) {
+                          csv = 1000L) {
   chk_s3_class(x, "ggplot")
   x_name <- chk_deparse(x_name)
   if (identical(x_name, "ggplot2::last_plot()")) {
@@ -664,7 +656,6 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
   chk_gt(dpi)
   chk_whole_number(csv)
   chk_gte(csv)
-  chk_flag(drop_uninformative_cols)
 
   csv <- as.integer(csv)
 
@@ -692,18 +683,16 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
   # only the first plot's data is saved as a csv, to maintain previous behaviour
   data <- plot_list[[1]]@data
   if (is.data.frame(data)) {
-    if (drop_uninformative_cols) {
-      data <- tidyplus::drop_uninformative_columns(data)
-    }
     if (nrow(data) && ncol(data) && nrow(data) <= csv) {
-      save_csv(data, "plots", sub = sub, main = main, x_name = x_name)
+      save_csv(tidyplus::drop_uninformative_columns(data),
+               "plots", sub = sub, main = main, x_name = x_name)
     }
   }
 
   sheet_list <- purrr::imap(plot_list, function(p, i) {
     c(
-      get_plot_data_sheet(p, i, drop_uninformative_cols),
-      get_plot_layer_sheets(p, i, csv, drop_uninformative_cols)
+      get_plot_data_sheet(p, i),
+      get_plot_layer_sheets(p, i, csv)
     )
   })
   sheet_list <- purrr::compact(purrr::list_flatten(sheet_list))

--- a/man/sbf_save_plot.Rd
+++ b/man/sbf_save_plot.Rd
@@ -17,7 +17,8 @@ sbf_save_plot(
   height = width,
   dpi = 300,
   limitsize = TRUE,
-  csv = 1000L
+  csv = 1000L,
+  drop_uninformative_cols = TRUE
 )
 }
 \arguments{
@@ -51,6 +52,13 @@ specifying dimensions in pixels.}
 
 \item{csv}{A count specifying the maximum number of rows to save as a csv
 file.}
+
+\item{drop_uninformative_cols}{A flag indicating whether to drop
+uninformative columns via \code{tidyplus::drop_uninformative_columns()}
+(\code{TRUE}; default) or not (\code{FALSE}).
+Currently soft-deprecated.
+Will be fully deprecated in future versions so that uninformative columns are
+always dropped in csv files and always kept in xlsx files.}
 }
 \description{
 Saves a ggplot object.
@@ -66,8 +74,6 @@ The function saves:
 and no more than \code{csv} rows. If \code{x} is a \code{patchwork} object, only the data
 for the first patch is saved, to maintain compatibility with previous
 versions.
-Uninformative columns are dropped via \code{tidyplus::drop_uninformative_columns()}
-using default arguments.
 \item An \code{xlsx} workbook with a sheet for the data passed to each \code{ggplot()}
 call and a sheet for each geom layer. Sheets are labelled \verb{<p>_<l>_<geom>},
 where \verb{<p>} is the patch index (1 for a simple \code{ggplot}), \verb{<l>} is the layer

--- a/man/sbf_save_plot.Rd
+++ b/man/sbf_save_plot.Rd
@@ -17,8 +17,7 @@ sbf_save_plot(
   height = width,
   dpi = 300,
   limitsize = TRUE,
-  csv = 1000L,
-  drop_uninformative_cols = TRUE
+  csv = 1000L
 )
 }
 \arguments{
@@ -52,10 +51,6 @@ specifying dimensions in pixels.}
 
 \item{csv}{A count specifying the maximum number of rows to save as a csv
 file.}
-
-\item{drop_uninformative_cols}{A flag indicating whether to drop
-uninformative columns via \code{tidyplus::drop_uninformative_columns()}
-(\code{TRUE}, default) or not (\code{FALSE}).}
 }
 \description{
 Saves a ggplot object.
@@ -71,6 +66,8 @@ The function saves:
 and no more than \code{csv} rows. If \code{x} is a \code{patchwork} object, only the data
 for the first patch is saved, to maintain compatibility with previous
 versions.
+Uninformative columns are dropped via \code{tidyplus::drop_uninformative_columns()}
+using default arguments.
 \item An \code{xlsx} workbook with a sheet for the data passed to each \code{ggplot()}
 call and a sheet for each geom layer. Sheets are labelled \verb{<p>_<l>_<geom>},
 where \verb{<p>} is the patch index (1 for a simple \code{ggplot}), \verb{<l>} is the layer

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -939,7 +939,7 @@ test_that("plot", {
   expect_identical(read.csv(file.path(sbf_get_main(), "plots", "y.csv")),
                    data.frame(x = 1:3, y = 2:4))
   expect_identical(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "y.xlsx")),
-                   dplyr::tibble(x = as.numeric(1:3), y = as.numeric(2:4), z = NA))
+                   dplyr::tibble(x = as.numeric(1:3), y = as.numeric(2:4)))
   expect_identical(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "y.xlsx")),
                    "1_0_data")
 
@@ -970,7 +970,7 @@ test_that("plot", {
     c("plot.png", "plot.rda", "plot.rds", "plot.xlsx", # has data but no layers
       "x.png", "x.rda", "x.rds", # no data or layers
       "y.csv", "y.png", "y.rda", "y.rds", "y.xlsx", # has data but no layers
-      "z.csv", "z.png", "z.rda", "z.rds", "z.xlsx") # data w one row and no layers
+      "z.png", "z.rda", "z.rds") # data w one row and no layers
   )
 
   data <- sbf_load_plots_recursive()
@@ -1033,29 +1033,28 @@ test_that("plot", {
       "plot.png", "plot.rda", "plot.rds", "plot.xlsx", # has data but no layers
       "x.png", "x.rda", "x.rds", # no data or layers
       "y.csv", "y.png", "y.rda", "y.rds", "y.xlsx", # has data but no layers
-      "z.csv", "z.png", "z.rda", "z.rds", "z.xlsx") # data w one row and no layers
+      "z.png", "z.rda", "z.rds") # data w one row and no layers
   )
   expect_equal(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_layers.xlsx")),
                c("1_1_point", "1_2_line", "1_3_line", "1_4_smooth"))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_1_point"),
-               (ggplot2::ggplot_build(p_layers)@data[[1]]) |>
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[1]]) |>
                  dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL),
-                               group = `attr<-`(group, "n", NULL)))
+                 dplyr::mutate(PANEL = as.character(PANEL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_2_line"),
-               (ggplot2::ggplot_build(p_layers)@data[[2]]) |>
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[2]]) |>
                  dplyr::tibble() |>
                  dplyr::mutate(PANEL = as.character(PANEL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_3_line"),
-               (ggplot2::ggplot_build(p_layers)@data[[3]]) |>
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[3]]) |>
                  dplyr::tibble() |>
                  dplyr::mutate(PANEL = as.character(PANEL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_4_smooth"),
-               (ggplot2::ggplot_build(p_layers)@data[[4]]) |>
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[4]]) |>
                  dplyr::tibble() |>
                  dplyr::mutate(PANEL = as.character(PANEL)))
 
@@ -1070,11 +1069,11 @@ test_that("plot", {
 
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_1_point") |>
-                 dplyr::select(x, y, PANEL, group, colour, alpha) |>
+                 dplyr::select(x, y, PANEL) |>
                  dplyr::arrange(x, y),
                readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_2_line") |>
-                 dplyr::select(x, y, PANEL, group, colour, alpha) |>
+                 dplyr::select(x, y, PANEL) |>
                  dplyr::arrange(x, y))
 
   # tests for checking that data for different patchwork patches save
@@ -1102,7 +1101,7 @@ test_that("plot", {
       "plot.png", "plot.rda", "plot.rds", "plot.xlsx", # has data but no layers
       "x.png", "x.rda", "x.rds", # no data or layers
       "y.csv", "y.png", "y.rda", "y.rds", "y.xlsx", # has data but no layers
-      "z.csv", "z.png", "z.rda", "z.rds", "z.xlsx") # has one-row data and no layers
+      "z.png", "z.rda", "z.rds") # has one-row data and no layers
   )
   expect_equal(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_patches.xlsx")),
                c("1_0_data", "1_1_line",
@@ -1115,38 +1114,29 @@ test_that("plot", {
                dplyr::tibble(datasets::mtcars))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "1_1_line"),
-               (ggplot2::ggplot_build(p_patches[[1]][[1]])@data[[1]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL),
-                               group = `attr<-`(group, "n", NULL)))
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[1]])@data[[1]]) |>
+                 dplyr::tibble())
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "2_1_line"),
-               (ggplot2::ggplot_build(p_patches[[1]][[2]])@data[[1]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL),
-                               group = `attr<-`(group, "n", NULL)))
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[2]])@data[[1]]) |>
+                 dplyr::tibble())
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "3_1_point"),
-               (ggplot2::ggplot_build(p_patches[[2]][[1]])@data[[1]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL),
-                               group = `attr<-`(group, "n", NULL)))
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[1]])@data[[1]]) |>
+                 dplyr::tibble())
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "4_0_data"),
                dplyr::tibble(datasets::iris) |>
                  dplyr::mutate(Species = as.character(Species)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "4_1_point"),
-               (ggplot2::ggplot_build(p_patches[[2]][[2]][[1]])@data[[1]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL),
-                               group = `attr<-`(group, "n", NULL)))
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[2]][[1]])@data[[1]]) |>
+                 dplyr::tibble())
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "5_1_point"),
-               (ggplot2::ggplot_build(p_patches[[2]][[2]][[2]])@data[[1]]) |>
+               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[2]][[2]])@data[[1]]) |>
                  dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL),
-                               group = `attr<-`(group, "n", NULL)))
+                 dplyr::mutate(group = `attr<-`(group, "n", NULL)))
   
   sbf_reset()
   sbf_close_windows()
@@ -2234,3 +2224,24 @@ test_that("`sbf_load_numbers_recursive()` drops only exact matches.", {
 
   expect_snapshot(numbers_onebone)
 })
+
+test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
+  expect_warning(
+    get_plot_data_sheet(ggplot2::ggplot(), prefix = 1,
+                        drop_uninformative_cols = TRUE),
+    p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`get_plot_data_sheet",
+       "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")
+)
+  expect_warning(
+    get_plot_layer_sheets(ggplot2::ggplot(), prefix = 1,
+                        drop_uninformative_cols = TRUE),
+    p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`get_plot_layer_sheets",
+       "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")
+  )
+  expect_warning(
+    sbf_save_plot(ggplot2::ggplot(), drop_uninformative_cols = TRUE),
+    p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`sbf_save_plot",
+       "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")
+  )
+})
+  

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2227,18 +2227,6 @@ test_that("`sbf_load_numbers_recursive()` drops only exact matches.", {
 
 test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
   expect_warning(
-    get_plot_data_sheet(ggplot2::ggplot(), prefix = 1,
-                        drop_uninformative_cols = TRUE),
-    p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`get_plot_data_sheet",
-       "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")
-)
-  expect_warning(
-    get_plot_layer_sheets(ggplot2::ggplot(), prefix = 1,
-                        drop_uninformative_cols = TRUE),
-    p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`get_plot_layer_sheets",
-       "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")
-  )
-  expect_warning(
     sbf_save_plot(ggplot2::ggplot(), drop_uninformative_cols = TRUE),
     p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`sbf_save_plot",
        "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2226,16 +2226,15 @@ test_that("`sbf_load_numbers_recursive()` drops only exact matches.", {
 })
 
 test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
-  options(lifecycle_verbosity = "warning")
-  setwd(withr::local_tempdir())
-  dir.create("output")
-  dir.create("output/plots")
-  sbf_set_main(file.path(getwd(), "output"))
-  expect_warning(
-    sbf_save_plot(ggplot2::ggplot(), x_name = "test_plot",
-                  drop_uninformative_cols = TRUE),
-    p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`sbf_save_plot",
-       "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")
-  )
+  sbf_reset()
+  sbf_set_main(file.path(withr::local_tempdir(), "output"))
+  withr::defer(sbf_reset())
+
+  gp <- ggplot2::ggplot() +
+  ggplot2::geom_point(ggplot2::aes(3, 3))
+    
+  lifecycle::expect_deprecated(sbf_save_plot(x = gp, x_name = "plot-1", drop_uninformative_cols = TRUE), 
+  p0("The `drop_uninformative_cols` argument of `sbf_save_plot",
+       "\\(\\)` is deprecated as of subfoldr2"))
 })
   

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2226,6 +2226,9 @@ test_that("`sbf_load_numbers_recursive()` drops only exact matches.", {
 })
 
 test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
+  setwd(withr::local_tempdir())
+  dir.create("output")
+  dir.create("output/plots")
   expect_warning(
     sbf_save_plot(ggplot2::ggplot(), drop_uninformative_cols = TRUE),
     p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`sbf_save_plot",

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2226,9 +2226,11 @@ test_that("`sbf_load_numbers_recursive()` drops only exact matches.", {
 })
 
 test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
+  options(lifecycle_verbosity = "warning")
   setwd(withr::local_tempdir())
   dir.create("output")
   dir.create("output/plots")
+  sbf_set_main(file.path(getwd(), "output"))
   expect_warning(
     sbf_save_plot(ggplot2::ggplot(), drop_uninformative_cols = TRUE),
     p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`sbf_save_plot",

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2232,7 +2232,8 @@ test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
   dir.create("output/plots")
   sbf_set_main(file.path(getwd(), "output"))
   expect_warning(
-    sbf_save_plot(ggplot2::ggplot(), drop_uninformative_cols = TRUE),
+    sbf_save_plot(ggplot2::ggplot(), x_name = "test_plot",
+                  drop_uninformative_cols = TRUE),
     p0("The\\s`drop_uninformative_cols`\\sargument\\sof\\s`sbf_save_plot",
        "\\(\\)`\\sis\\sdeprecated\\sas\\sof\\ssubfoldr2\\sVERSION.")
   )

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -897,8 +897,7 @@ test_that("plot", {
   )
 
   x <- ggplot2::ggplot()
-  expect_identical(sbf_save_plot(x, drop_uninformative_cols = TRUE),
-                   file.path(sbf_get_main(), "plots/x.rds"))
+  expect_identical(sbf_save_plot(x), file.path(sbf_get_main(), "plots/x.rds"))
   expect_true(all.equal(sbf_load_plot("x"), x))
   expect_identical(sbf_load_plot_data("x"), data.frame())
 
@@ -913,16 +912,14 @@ test_that("plot", {
     data = data.frame(x = 1, y = 2, z = NA_real_),
     ggplot2::aes(x = x, y = y)
   )
-  expect_identical(sbf_save_plot(y, drop_uninformative_cols = TRUE),
-                   file.path(sbf_get_main(), "plots/y.rds"))
+  expect_identical(sbf_save_plot(y), file.path(sbf_get_main(), "plots/y.rds"))
   expect_false(file.exists(paste0(sbf_get_main(), "plots/y.csv")))
   
   y <- ggplot2::ggplot(
     data = data.frame(x = 1:3, y = 2:4, z = NA_real_),
     ggplot2::aes(x = x, y = y)
   )
-  expect_identical(sbf_save_plot(y, drop_uninformative_cols = FALSE),
-                   file.path(sbf_get_main(), "plots/y.rds"))
+  expect_identical(sbf_save_plot(y), file.path(sbf_get_main(), "plots/y.rds"))
   expect_identical(
     list.files(file.path(sbf_get_main(), "plots")),
     sort(c(
@@ -933,7 +930,7 @@ test_that("plot", {
     ))
   )
   expect_identical(read.csv(file.path(sbf_get_main(), "plots/y.csv")),
-                   data.frame(x = 1:3, y = 2:4, z = NA))
+                   data.frame(x = 1:3, y = 2:4))
 
   expect_identical(sbf_save_plot(y), file.path(sbf_get_main(), "plots/y.rds"))
   expect_true(all.equal(sbf_load_plot("y"), y))
@@ -942,7 +939,7 @@ test_that("plot", {
   expect_identical(read.csv(file.path(sbf_get_main(), "plots", "y.csv")),
                    data.frame(x = 1:3, y = 2:4))
   expect_identical(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "y.xlsx")),
-                   dplyr::tibble(x = as.numeric(1:3), y = as.numeric(2:4)))
+                   dplyr::tibble(x = as.numeric(1:3), y = as.numeric(2:4), z = NA))
   expect_identical(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "y.xlsx")),
                    "1_0_data")
 
@@ -973,7 +970,7 @@ test_that("plot", {
     c("plot.png", "plot.rda", "plot.rds", "plot.xlsx", # has data but no layers
       "x.png", "x.rda", "x.rds", # no data or layers
       "y.csv", "y.png", "y.rda", "y.rds", "y.xlsx", # has data but no layers
-      "z.png", "z.rda", "z.rds") # dataset has only one row and no layers
+      "z.csv", "z.png", "z.rda", "z.rds", "z.xlsx") # data w one row and no layers
   )
 
   data <- sbf_load_plots_recursive()
@@ -1036,28 +1033,29 @@ test_that("plot", {
       "plot.png", "plot.rda", "plot.rds", "plot.xlsx", # has data but no layers
       "x.png", "x.rda", "x.rds", # no data or layers
       "y.csv", "y.png", "y.rda", "y.rds", "y.xlsx", # has data but no layers
-      "z.png", "z.rda", "z.rds") # has one-row data and no layers
+      "z.csv", "z.png", "z.rda", "z.rds", "z.xlsx") # data w one row and no layers
   )
   expect_equal(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_layers.xlsx")),
                c("1_1_point", "1_2_line", "1_3_line", "1_4_smooth"))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[1]]) |>
+               (ggplot2::ggplot_build(p_layers)@data[[1]]) |>
                  dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL)))
+                 dplyr::mutate(PANEL = as.character(PANEL),
+                               group = `attr<-`(group, "n", NULL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_2_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[2]]) |>
+               (ggplot2::ggplot_build(p_layers)@data[[2]]) |>
                  dplyr::tibble() |>
                  dplyr::mutate(PANEL = as.character(PANEL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_3_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[3]]) |>
+               (ggplot2::ggplot_build(p_layers)@data[[3]]) |>
                  dplyr::tibble() |>
                  dplyr::mutate(PANEL = as.character(PANEL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_4_smooth"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[4]]) |>
+               (ggplot2::ggplot_build(p_layers)@data[[4]]) |>
                  dplyr::tibble() |>
                  dplyr::mutate(PANEL = as.character(PANEL)))
 
@@ -1072,9 +1070,11 @@ test_that("plot", {
 
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_1_point") |>
+                 dplyr::select(x, y, PANEL, group, colour, alpha) |>
                  dplyr::arrange(x, y),
                readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
                                  "1_2_line") |>
+                 dplyr::select(x, y, PANEL, group, colour, alpha) |>
                  dplyr::arrange(x, y))
 
   # tests for checking that data for different patchwork patches save
@@ -1102,7 +1102,7 @@ test_that("plot", {
       "plot.png", "plot.rda", "plot.rds", "plot.xlsx", # has data but no layers
       "x.png", "x.rda", "x.rds", # no data or layers
       "y.csv", "y.png", "y.rda", "y.rds", "y.xlsx", # has data but no layers
-      "z.png", "z.rda", "z.rds") # has one-row data and no layers
+      "z.csv", "z.png", "z.rda", "z.rds", "z.xlsx") # has one-row data and no layers
   )
   expect_equal(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_patches.xlsx")),
                c("1_0_data", "1_1_line",
@@ -1115,30 +1115,39 @@ test_that("plot", {
                dplyr::tibble(datasets::mtcars))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "1_1_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[1]])@data[[1]]) |>
-                 dplyr::tibble())
+               (ggplot2::ggplot_build(p_patches[[1]][[1]])@data[[1]]) |>
+                 dplyr::tibble() |>
+                 dplyr::mutate(PANEL = as.character(PANEL),
+                               group = `attr<-`(group, "n", NULL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "2_1_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[2]])@data[[1]]) |>
-                 dplyr::tibble())
+               (ggplot2::ggplot_build(p_patches[[1]][[2]])@data[[1]]) |>
+                 dplyr::tibble() |>
+                 dplyr::mutate(PANEL = as.character(PANEL),
+                               group = `attr<-`(group, "n", NULL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "3_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[1]])@data[[1]]) |>
-                 dplyr::tibble())
+               (ggplot2::ggplot_build(p_patches[[2]][[1]])@data[[1]]) |>
+                 dplyr::tibble() |>
+                 dplyr::mutate(PANEL = as.character(PANEL),
+                               group = `attr<-`(group, "n", NULL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "4_0_data"),
                dplyr::tibble(datasets::iris) |>
                  dplyr::mutate(Species = as.character(Species)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "4_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[2]][[1]])@data[[1]]) |>
-                 dplyr::tibble())
+               (ggplot2::ggplot_build(p_patches[[2]][[2]][[1]])@data[[1]]) |>
+                 dplyr::tibble() |>
+                 dplyr::mutate(PANEL = as.character(PANEL),
+                               group = `attr<-`(group, "n", NULL)))
   expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
                                  "5_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[2]][[2]])@data[[1]]) |>
-                 dplyr::tibble() %>%
-                 dplyr::mutate(group = as.numeric(group)))
-
+               (ggplot2::ggplot_build(p_patches[[2]][[2]][[2]])@data[[1]]) |>
+                 dplyr::tibble() |>
+                 dplyr::mutate(PANEL = as.character(PANEL),
+                               group = `attr<-`(group, "n", NULL)))
+  
   sbf_reset()
   sbf_close_windows()
 })


### PR DESCRIPTION
- all `csv` files now have uninformative columns dropped to keep them lightweight.
- all `xlsx` files now have all columns to remain as complete as possible. sheets with more than `csv` rows are still not saved.

@joethorley and I had discussed removing the argument to avoid issues with the function dropping columns that are informative despite having a single value (e.g., color, fill, group, facet). The change was motivated by a single-facet patchwork plot like the one below:
<img width="1398" height="598" alt="image" src="https://github.com/user-attachments/assets/2541c7f3-ef71-42eb-ac93-87532ce76de8" />
