### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/archive.R
+++ b/R/archive.R
@@ -11,14 +11,16 @@
 #' @family  archive
 #' @family housekeeping functions
 #' @export
-sbf_archive_main <- function(main = sbf_get_main(),
-                             ask = getOption("sbf.ask", TRUE),
-                             tz = dtt_default_tz()) {
+sbf_archive_main <- function(
+  main = sbf_get_main(),
+  ask = getOption("sbf.ask", TRUE),
+  tz = dtt_default_tz()
+) {
   chk_string(main)
   chk_flag(ask)
   chk_string(tz)
 
-  if(!vld_dir(main)) {
+  if (!vld_dir(main)) {
     cli::cli_alert_info(paste0("Directory '", main, "' does not exist."))
     return(invisible(character()))
   }
@@ -36,7 +38,13 @@ sbf_archive_main <- function(main = sbf_get_main(),
 
   if (!ask || yesno(msg)) {
     fs::dir_copy(main, archive, overwrite = FALSE)
-    cli::cli_alert_success(paste0("Directory '", main, "' copied to '", archive, "'"))
+    cli::cli_alert_success(paste0(
+      "Directory '",
+      main,
+      "' copied to '",
+      archive,
+      "'"
+    ))
   } else {
     cli::cli_alert_warning(paste0("Directory '", main, "' was not copied"))
   }
@@ -57,9 +65,11 @@ sbf_archive_main <- function(main = sbf_get_main(),
 #' @family  archive
 #' @family housekeeping functions
 #' @export
-sbf_unarchive_main <- function(main = sbf_get_main(),
-                               archive = 1L,
-                               ask = getOption("sbf.ask", TRUE)) {
+sbf_unarchive_main <- function(
+  main = sbf_get_main(),
+  archive = 1L,
+  ask = getOption("sbf.ask", TRUE)
+) {
   if (!vld_whole_number(archive) && !vld_dir(archive)) {
     chkor_vld(vld_whole_number(archive), vld_dir(archive))
   }
@@ -95,7 +105,8 @@ sbf_get_archive <- function(main = sbf_get_main(), archive = 1L) {
   chk_whole_number(archive)
   chk_gt(archive)
 
-  files <- fs::dir_ls(dirname(main),
+  files <- fs::dir_ls(
+    dirname(main),
     type = "directory",
     regexp = ".*-\\d{4,4}(-\\d{2,2}){5,5}$"
   )
@@ -103,8 +114,10 @@ sbf_get_archive <- function(main = sbf_get_main(), archive = 1L) {
   if (!length(files)) {
     stop(
       "There are no archived folders for '",
-      basename(main), "' in '",
-      dirname(main), "'."
+      basename(main),
+      "' in '",
+      dirname(main),
+      "'."
     )
   }
 
@@ -113,8 +126,10 @@ sbf_get_archive <- function(main = sbf_get_main(), archive = 1L) {
       "There are only ",
       length(files),
       " archived folders for '",
-      basename(main), "' in '",
-      dirname(main), "'."
+      basename(main),
+      "' in '",
+      dirname(main),
+      "'."
     )
   }
 

--- a/R/check.R
+++ b/R/check.R
@@ -1,4 +1,9 @@
 is_valid_table_column <- function(x) {
-  is.logical(x) || is.numeric(x) || is.character(x) || is.factor(x) ||
-    is.Date(x) || hms::is_hms(x) || is.POSIXct(x)
+  is.logical(x) ||
+    is.numeric(x) ||
+    is.character(x) ||
+    is.factor(x) ||
+    is.Date(x) ||
+    hms::is_hms(x) ||
+    is.POSIXct(x)
 }

--- a/R/compare.R
+++ b/R/compare.R
@@ -9,10 +9,14 @@
 #' @return A character vector with class "waldo_compare".
 #' @family compare functions
 #' @export
-sbf_compare_data <- function(x, x_name = substitute(x),
-                             sub = sbf_get_sub(), main = sbf_get_main(),
-                             tolerance = sqrt(.Machine$double.eps),
-                             ignore_attr = FALSE) {
+sbf_compare_data <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  tolerance = sqrt(.Machine$double.eps),
+  ignore_attr = FALSE
+) {
   rlang::check_installed("waldo")
 
   chk_s3_class(x, "data.frame")
@@ -22,8 +26,11 @@ sbf_compare_data <- function(x, x_name = substitute(x),
   main <- sanitize_path(main, rm_leading = FALSE)
 
   existing <- sbf_load_data(x_name, sub = sub, main = main, exists = NA)
-  waldo::compare(existing, x,
-    x_arg = "saved", y_arg = "current",
+  waldo::compare(
+    existing,
+    x,
+    x_arg = "saved",
+    y_arg = "current",
     tolerance = tolerance,
     ignore_attr = ignore_attr
   )
@@ -42,13 +49,16 @@ sbf_compare_data <- function(x, x_name = substitute(x),
 #' @return A named list of character vectors.
 #' @family compare functions
 #' @export
-sbf_compare_data_archive <- function(x_name = ".*", sub = sbf_get_sub(),
-                                     main = sbf_get_main(),
-                                     archive = 1L,
-                                     recursive = FALSE,
-                                     include_root = TRUE,
-                                     tolerance = sqrt(.Machine$double.eps),
-                                     ignore_attr = FALSE) {
+sbf_compare_data_archive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  archive = 1L,
+  recursive = FALSE,
+  include_root = TRUE,
+  tolerance = sqrt(.Machine$double.eps),
+  ignore_attr = FALSE
+) {
   rlang::check_installed("waldo")
 
   if (!vld_whole_number(archive) && !vld_dir(archive)) {
@@ -59,13 +69,19 @@ sbf_compare_data_archive <- function(x_name = ".*", sub = sbf_get_sub(),
   }
 
   main_files <- sbf_list_datas(
-    x_name = x_name, sub = sub, main = main,
-    recursive = recursive, include_root = include_root
+    x_name = x_name,
+    sub = sub,
+    main = main,
+    recursive = recursive,
+    include_root = include_root
   )
 
   archive_files <- sbf_list_datas(
-    x_name = x_name, sub = sub, main = archive,
-    recursive = recursive, include_root = include_root
+    x_name = x_name,
+    sub = sub,
+    main = archive,
+    recursive = recursive,
+    include_root = include_root
   )
 
   all_file_names <- union(names(main_files), names(archive_files))
@@ -76,9 +92,12 @@ sbf_compare_data_archive <- function(x_name = ".*", sub = sbf_get_sub(),
 
   all_file_names <- sort(all_file_names)
 
-  compare <- lapply(all_file_names,
+  compare <- lapply(
+    all_file_names,
     FUN = compare_data,
-    main = main, archive = archive, tolerance = tolerance,
+    main = main,
+    archive = archive,
+    tolerance = tolerance,
     ignore_attr = ignore_attr
   )
   names(compare) <- all_file_names

--- a/R/convert.R
+++ b/R/convert.R
@@ -11,8 +11,10 @@
 #' created.
 #' @family housekeeping functions
 #' @export
-sbf_convert_meta <- function(main = sbf_get_main(),
-                             ask = getOption("sbf.ask", TRUE)) {
+sbf_convert_meta <- function(
+  main = sbf_get_main(),
+  ask = getOption("sbf.ask", TRUE)
+) {
   chk_string(main)
   chk_flag(ask)
 
@@ -23,8 +25,12 @@ sbf_convert_meta <- function(main = sbf_get_main(),
     return(invisible(character(0)))
   }
 
-  files <- list.files(main, pattern = "[.]rda$", recursive = TRUE,
-                      full.names = TRUE)
+  files <- list.files(
+    main,
+    pattern = "[.]rda$",
+    recursive = TRUE,
+    full.names = TRUE
+  )
 
   if (!length(files)) {
     cli::cli_alert_info("No '.rda' metadata files to convert.")
@@ -32,22 +38,31 @@ sbf_convert_meta <- function(main = sbf_get_main(),
   }
 
   msg <- paste0(
-    "Convert ", length(files), " '.rda' metadata file",
-    if (length(files) > 1) "s" else "", " in directory '", main,
+    "Convert ",
+    length(files),
+    " '.rda' metadata file",
+    if (length(files) > 1) "s" else "",
+    " in directory '",
+    main,
     "' to '.yaml' and delete the '.rda' file",
-    if (length(files) > 1) "s" else "", "?"
+    if (length(files) > 1) "s" else "",
+    "?"
   )
   if (ask && !yesno(msg)) {
     return(invisible(character(0)))
   }
 
-  yaml_files <- vapply(files, function(file) {
-    meta <- readRDS(file)
-    yaml_file <- replace_ext(file, "yaml")
-    yaml::write_yaml(meta, yaml_file)
-    file.remove(file)
-    yaml_file
-  }, character(1))
+  yaml_files <- vapply(
+    files,
+    function(file) {
+      meta <- readRDS(file)
+      yaml_file <- replace_ext(file, "yaml")
+      yaml::write_yaml(meta, yaml_file)
+      file.remove(file)
+      yaml_file
+    },
+    character(1)
+  )
   yaml_files <- unname(yaml_files)
 
   cli::cli_alert_success(

--- a/R/copy.R
+++ b/R/copy.R
@@ -14,11 +14,14 @@
 #' @return A flag indicating whether successfully copied.
 #' @family database functions
 #' @export
-sbf_copy_db <- function(path, db_name = sbf_get_db_name(),
-                        sub = sbf_get_sub(),
-                        main = sbf_get_main(),
-                        exists = FALSE,
-                        ask = getOption("sbf.ask", TRUE)) {
+sbf_copy_db <- function(
+  path,
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = FALSE,
+  ask = getOption("sbf.ask", TRUE)
+) {
   chk_ext(path, c("db", "sqlite", "sqlite3"))
   chk_file(path)
 
@@ -33,7 +36,9 @@ sbf_copy_db <- function(path, db_name = sbf_get_db_name(),
 
   file <- file_name(main, "dbs", sub, db_name, ext = "sqlite")
 
-  if (isTRUE(exists)) chk_file(file)
+  if (isTRUE(exists)) {
+    chk_file(file)
+  }
 
   if (isFALSE(exists) && file.exists(file)) {
     if (ask && !yesno("Delete file '", file, "'?")) {

--- a/R/create-db.R
+++ b/R/create-db.R
@@ -6,13 +6,18 @@
 #' existing database.
 #' @family database functions
 #' @export
-sbf_create_db <- function(db_name = sbf_get_db_name(),
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main(),
-                          ask = getOption("sbf.ask", TRUE)) {
+sbf_create_db <- function(
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ask = getOption("sbf.ask", TRUE)
+) {
   conn <- sbf_open_db(
-    db_name = db_name, sub = sub, main = main,
-    exists = FALSE, ask = ask
+    db_name = db_name,
+    sub = sub,
+    main = main,
+    exists = FALSE,
+    ask = ask
   )
   sbf_close_db(conn)
 }

--- a/R/diff.R
+++ b/R/diff.R
@@ -8,17 +8,21 @@
 #' @return A daff difference object.
 #' @family compare functions
 #' @export
-sbf_diff_data <- function(x,
-                          x_name = substitute(x),
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main()) {
+sbf_diff_data <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   chk_s3_class(x, "data.frame")
   x_name <- chk_deparse(x_name)
 
   rlang::check_installed("daff")
 
   existing <- sbf_load_data(x_name, sub = sub, main = main, exists = NA)
-  if (is.null(existing)) existing <- x
+  if (is.null(existing)) {
+    existing <- x
+  }
   daff::diff_data(existing, x)
 }
 
@@ -37,13 +41,15 @@ sbf_diff_data <- function(x,
 #' @return A named list of character vectors.
 #' @family compare functions
 #' @export
-sbf_diff_data_archive <- function(x_name = ".*",
-                                  sub = sbf_get_sub(),
-                                  main = sbf_get_main(),
-                                  archive = 1L,
-                                  recursive = FALSE,
-                                  include_root = TRUE,
-                                  exists = NA) {
+sbf_diff_data_archive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  archive = 1L,
+  recursive = FALSE,
+  include_root = TRUE,
+  exists = NA
+) {
   chk_lgl(exists)
 
   rlang::check_installed("daff")
@@ -56,13 +62,19 @@ sbf_diff_data_archive <- function(x_name = ".*",
   }
 
   main_files <- sbf_list_datas(
-    x_name = x_name, sub = sub, main = main,
-    recursive = recursive, include_root = include_root
+    x_name = x_name,
+    sub = sub,
+    main = main,
+    recursive = recursive,
+    include_root = include_root
   )
 
   archive_files <- sbf_list_datas(
-    x_name = x_name, sub = sub, main = archive,
-    recursive = recursive, include_root = include_root
+    x_name = x_name,
+    sub = sub,
+    main = archive,
+    recursive = recursive,
+    include_root = include_root
   )
 
   all_file_names <- union(names(main_files), names(archive_files))
@@ -73,9 +85,11 @@ sbf_diff_data_archive <- function(x_name = ".*",
 
   all_file_names <- sort(all_file_names)
 
-  diff <- lapply(all_file_names,
+  diff <- lapply(
+    all_file_names,
     FUN = diff_data,
-    main = main, archive = archive
+    main = main,
+    archive = archive
   )
   names(diff) <- all_file_names
   diff
@@ -91,17 +105,21 @@ sbf_diff_data_archive <- function(x_name = ".*",
 #' @return A daff difference object.
 #' @family compare functions
 #' @export
-sbf_diff_table <- function(x,
-                           x_name = substitute(x),
-                           sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           exists = NA) {
+sbf_diff_table <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = NA
+) {
   chk_s3_class(x, "data.frame")
   x_name <- chk_deparse(x_name)
 
   rlang::check_installed("daff")
 
   existing <- sbf_load_table(x_name, sub = sub, main = main, exists = exists)
-  if (is.null(existing)) existing <- x
+  if (is.null(existing)) {
+    existing <- x
+  }
   daff::diff_data(existing, x)
 }

--- a/R/equal.R
+++ b/R/equal.R
@@ -10,12 +10,15 @@
 #' @return A named flag.
 #' @family compare functions
 #' @export
-sbf_is_equal_data <- function(x, x_name = substitute(x),
-                              sub = sbf_get_sub(),
-                              main = sbf_get_main(),
-                              exists = TRUE,
-                              tolerance = sqrt(.Machine$double.eps),
-                              check.attributes = TRUE) {
+sbf_is_equal_data <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE,
+  tolerance = sqrt(.Machine$double.eps),
+  check.attributes = TRUE
+) {
   chk_s3_class(x, "data.frame")
   x_name <- chk_deparse(x_name)
   chk_scalar(exists)
@@ -30,7 +33,9 @@ sbf_is_equal_data <- function(x, x_name = substitute(x),
   if (is.null(existing)) {
     return(setNames(!exists, file))
   }
-  equal <- vld_true(all.equal(existing, x,
+  equal <- vld_true(all.equal(
+    existing,
+    x,
     tolerance = tolerance,
     check.attributes = check.attributes
   ))
@@ -51,15 +56,17 @@ sbf_is_equal_data <- function(x, x_name = substitute(x),
 #' @return A named logical vector.
 #' @family compare functions
 #' @export
-sbf_is_equal_data_archive <- function(x_name = ".*",
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main(),
-                                      archive = 1L,
-                                      recursive = FALSE,
-                                      include_root = TRUE,
-                                      exists = TRUE,
-                                      tolerance = sqrt(.Machine$double.eps),
-                                      check.attributes = TRUE) {
+sbf_is_equal_data_archive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  archive = 1L,
+  recursive = FALSE,
+  include_root = TRUE,
+  exists = TRUE,
+  tolerance = sqrt(.Machine$double.eps),
+  check.attributes = TRUE
+) {
   if (!vld_whole_number(archive) && !vld_dir(archive)) {
     chkor_vld(vld_whole_number(archive), vld_dir(archive))
   }
@@ -68,13 +75,19 @@ sbf_is_equal_data_archive <- function(x_name = ".*",
   }
 
   main_files <- sbf_list_datas(
-    x_name = x_name, sub = sub, main = main,
-    recursive = recursive, include_root = include_root
+    x_name = x_name,
+    sub = sub,
+    main = main,
+    recursive = recursive,
+    include_root = include_root
   )
 
   archive_files <- sbf_list_datas(
-    x_name = x_name, sub = sub, main = archive,
-    recursive = recursive, include_root = include_root
+    x_name = x_name,
+    sub = sub,
+    main = archive,
+    recursive = recursive,
+    include_root = include_root
   )
 
   all_file_names <- union(names(main_files), names(archive_files))
@@ -88,9 +101,13 @@ sbf_is_equal_data_archive <- function(x_name = ".*",
   equal <- equal[order(names(equal))]
 
   shared_file_names <- intersect(names(main_files), names(archive_files))
-  all_equal <- vapply(shared_file_names,
-    FUN = all_equal_data, TRUE,
-    main = main, archive = archive, tolerance = tolerance,
+  all_equal <- vapply(
+    shared_file_names,
+    FUN = all_equal_data,
+    TRUE,
+    main = main,
+    archive = archive,
+    tolerance = tolerance,
     check.attributes = check.attributes
   )
 

--- a/R/execute-db.R
+++ b/R/execute-db.R
@@ -8,9 +8,12 @@
 #' @return A scalar numeric of the number of rows affected by the statement.
 #' @family database functions
 #' @export
-sbf_execute_db <- function(sql, db_name = sbf_get_db_name(),
-                           sub = sbf_get_sub(),
-                           main = sbf_get_main()) {
+sbf_execute_db <- function(
+  sql,
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   chk_string(sql)
   chk_gt(nchar(sql))
 

--- a/R/exists.R
+++ b/R/exists.R
@@ -9,9 +9,11 @@ exists_rds <- function(x_name, class, sub, main) {
 #' @return A flag specifying whether the object exists.
 #' @family exists functions
 #' @export
-sbf_object_exists <- function(x_name,
-                              sub = sbf_get_sub(),
-                              main = sbf_get_main()) {
+sbf_object_exists <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   lifecycle::deprecate_soft("0.0.0.9045", "sbf_object_exists()")
   exists_rds(x_name, class = "objects", sub = sub, main = main)
 }
@@ -23,9 +25,11 @@ sbf_object_exists <- function(x_name,
 #' @return A flag specifying whether the data exists.
 #' @family exists functions
 #' @export
-sbf_data_exists <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main()) {
+sbf_data_exists <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   lifecycle::deprecate_soft("0.0.0.9045", "sbf_data_exists()")
   exists_rds(x_name, class = "data", sub = sub, main = main)
 }
@@ -37,9 +41,11 @@ sbf_data_exists <- function(x_name,
 #' @return A flag specifying whether the number exists.
 #' @family exists functions
 #' @export
-sbf_number_exists <- function(x_name,
-                              sub = sbf_get_sub(),
-                              main = sbf_get_main()) {
+sbf_number_exists <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   lifecycle::deprecate_soft("0.0.0.9045", "sbf_number_exists()")
   exists_rds(x_name, class = "numbers", sub = sub, main = main)
 }
@@ -50,9 +56,11 @@ sbf_number_exists <- function(x_name,
 #' @return A flag specifying whether the string exists.
 #' @family exists functions
 #' @export
-sbf_string_exists <- function(x_name,
-                              sub = sbf_get_sub(),
-                              main = sbf_get_main()) {
+sbf_string_exists <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   lifecycle::deprecate_soft("0.0.0.9045", "sbf_string_exists()")
   exists_rds(x_name, class = "strings", sub = sub, main = main)
 }
@@ -63,9 +71,11 @@ sbf_string_exists <- function(x_name,
 #' @return A flag specifying whether the block exists.
 #' @family exists functions
 #' @export
-sbf_block_exists <- function(x_name,
-                             sub = sbf_get_sub(),
-                             main = sbf_get_main()) {
+sbf_block_exists <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   lifecycle::deprecate_soft("0.0.0.9045", "sbf_block_exists()")
   exists_rds(x_name, class = "blocks", sub = sub, main = main)
 }
@@ -76,9 +86,11 @@ sbf_block_exists <- function(x_name,
 #' @return A flag specifying whether the table exists.
 #' @family exists functions
 #' @export
-sbf_table_exists <- function(x_name,
-                             sub = sbf_get_sub(),
-                             main = sbf_get_main()) {
+sbf_table_exists <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   lifecycle::deprecate_soft("0.0.0.9045", "sbf_table_exists()")
   exists_rds(x_name, class = "tables", sub = sub, main = main)
 }
@@ -89,9 +101,11 @@ sbf_table_exists <- function(x_name,
 #' @return A flag specifying whether the plot exists.
 #' @family exists functions
 #' @export
-sbf_plot_exists <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main()) {
+sbf_plot_exists <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   lifecycle::deprecate_soft("0.0.0.9045", "sbf_plot_exists()")
   exists_rds(x_name, class = "plots", sub = sub, main = main)
 }

--- a/R/flob.R
+++ b/R/flob.R
@@ -8,18 +8,21 @@
 #' @return Invisible TRUE.
 #' @family database functions
 #' @export
-sbf_add_blob_column_to_db <- function(column_name,
-                                      table_name,
-                                      db_name = sbf_get_db_name(),
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main()) {
+sbf_add_blob_column_to_db <- function(
+  column_name,
+  table_name,
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   rlang::check_installed("dbflobr")
 
   conn <- sbf_open_db(db_name = db_name, sub = sub, main = main, exists = TRUE)
   on.exit(sbf_close_db(conn))
 
   dbflobr::add_blob_column(
-    column_name = column_name, table_name = table_name,
+    column_name = column_name,
+    table_name = table_name,
     conn = conn
   )
 }
@@ -41,12 +44,14 @@ sbf_add_blob_column_to_db <- function(column_name,
 #' @return An invisible named list of named vectors of the file names and new
 #' file names saved.
 #' @export
-sbf_save_flobs_from_db <- function(db_name = sbf_get_db_name(),
-                                   sub = sbf_get_sub(),
-                                   main = sbf_get_main(),
-                                   dir = NULL,
-                                   dbflobr_sub = FALSE,
-                                   replace = FALSE) {
+sbf_save_flobs_from_db <- function(
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  dir = NULL,
+  dbflobr_sub = FALSE,
+  replace = FALSE
+) {
   rlang::check_installed("dbflobr")
 
   conn <- sbf_open_db(db_name = db_name, sub = sub, main = main, exists = TRUE)
@@ -86,13 +91,15 @@ sbf_save_flobs_from_db <- function(db_name = sbf_get_db_name(),
 #' whether files were successfully written to database.
 #' @family database functions
 #' @export
-sbf_upload_flobs_to_db <- function(db_name = sbf_get_db_name(),
-                                   sub = sbf_get_sub(),
-                                   main = sbf_get_main(),
-                                   dir = NULL,
-                                   dbflobr_sub = FALSE,
-                                   exists = FALSE,
-                                   replace = FALSE) {
+sbf_upload_flobs_to_db <- function(
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  dir = NULL,
+  dbflobr_sub = FALSE,
+  exists = FALSE,
+  replace = FALSE
+) {
   rlang::check_installed("dbflobr")
 
   conn <- sbf_open_db(db_name = db_name, sub = sub, main = main, exists = TRUE)
@@ -104,7 +111,10 @@ sbf_upload_flobs_to_db <- function(db_name = sbf_get_db_name(),
     dir <- file_path(main, "flobs", sub, db_name)
   }
   dbflobr::import_all_flobs(
-    conn = conn, dir = dir, exists = exists, replace = replace,
+    conn = conn,
+    dir = dir,
+    exists = exists,
+    replace = replace,
     sub = dbflobr_sub
   )
 }

--- a/R/internal.R
+++ b/R/internal.R
@@ -27,7 +27,9 @@ file_path <- function(..., collapse = FALSE) {
 sanitize_path <- function(path, rm_leading = TRUE) {
   path <- sub("//", "/", path)
   path <- sub("(.+)(/$)", "\\1", path)
-  if (isTRUE(rm_leading)) path <- sub("(^/)(.*)", "\\2", path)
+  if (isTRUE(rm_leading)) {
+    path <- sub("(^/)(.*)", "\\2", path)
+  }
   path
 }
 
@@ -77,11 +79,12 @@ sub_name <- function(data) {
     return(data)
   }
   data <- data[!grepl("^sub\\d", colnames(data))]
-  data$sub <- apply(sub,
-    MARGIN = 1,
-    function(x) paste0(na_omit(x), collapse = "/")
-  )
-  if (ncol(sub) > 1) data <- cbind(data, sub)
+  data$sub <- apply(sub, MARGIN = 1, function(x) {
+    paste0(na_omit(x), collapse = "/")
+  })
+  if (ncol(sub) > 1) {
+    data <- cbind(data, sub)
+  }
   data
 }
 
@@ -122,11 +125,7 @@ get_plot_data <- function(x) {
 }
 
 plot_size <- function(dim, units) {
-  dim <- dim / switch(units,
-    "in" = 1,
-    "cm" = 2.54,
-    "mm" = 25.4
-  )
+  dim <- dim / switch(units, "in" = 1, "cm" = 2.54, "mm" = 25.4)
 
   if (any(is.na(dim))) {
     if (!length(grDevices::dev.list())) {
@@ -203,7 +202,9 @@ all_equal_data <- function(name, main, archive, tolerance, check.attributes) {
   main <- readRDS(main)
   archive <- readRDS(archive)
 
-  vld_true(all.equal(main, archive,
+  vld_true(all.equal(
+    main,
+    archive,
     tolerance = tolerance,
     check.attributes = check.attributes
   ))
@@ -219,8 +220,11 @@ compare_data <- function(name, main, archive, tolerance, ignore_attr) {
   main <- if (file.exists(main)) readRDS(main) else NULL
   archive <- if (file.exists(archive)) readRDS(archive) else NULL
 
-  waldo::compare(archive, main,
-    x_arg = "archive", y_arg = "main",
+  waldo::compare(
+    archive,
+    main,
+    x_arg = "archive",
+    y_arg = "main",
     tolerance = tolerance,
     ignore_attr = ignore_attr
   )
@@ -245,9 +249,11 @@ diff_data <- function(name, main, archive) {
   daff::diff_data(archive, main)
 }
 
-convert_coords_to_sfc <- function(x,
-                                  coords = c("X", "Y"),
-                                  sfc_name = "geometry") {
+convert_coords_to_sfc <- function(
+  x,
+  coords = c("X", "Y"),
+  sfc_name = "geometry"
+) {
   # this is a simplified version of ps_coords_to_sfc
   chk::chk_s3_class(x, "data.frame")
   chk::chk_vector(coords)
@@ -262,7 +268,8 @@ convert_coords_to_sfc <- function(x,
 
   y <- x[!is.na(x[[coords[1]]]) & !is.na(x[[coords[2]]]), ]
 
-  sfc <- sf::st_multipoint(matrix(c(y[[coords[1]]], y[[coords[2]]]), ncol = 2),
+  sfc <- sf::st_multipoint(
+    matrix(c(y[[coords[1]]], y[[coords[2]]]), ncol = 2),
     dim = "XY"
   )
   sfc <- sf::st_sfc(sfc, crs = 4326)
@@ -288,17 +295,17 @@ convert_coords_to_sfc <- function(x,
 
 check_is_sfc <- function(x) {
   sfc_names <- colnames(x)
-  sfc_names <- sfc_names[vapply(x, function(x) {
-    inherits(x, "sfc")
-  }, TRUE)]
+  sfc_names <- sfc_names[vapply(
+    x,
+    function(x) {
+      inherits(x, "sfc")
+    },
+    TRUE
+  )]
   sfc_names
 }
 
-convert_sfc_to_coords <- function(x,
-                                  sfc_name,
-                                  X = "X",
-                                  Y = "Y",
-                                  Z = "Z") {
+convert_sfc_to_coords <- function(x, sfc_name, X = "X", Y = "Y", Z = "Z") {
   # this is a simplified version of ps_sfc_to_coords
   chk::chk_s3_class(x, "data.frame")
   chk::chk_string(sfc_name)
@@ -306,14 +313,18 @@ convert_sfc_to_coords <- function(x,
   chk::chk_string(Y)
   chk::chk_string(Z)
 
-  if (!(class(x[[sfc_name]])[[1]] %in% c("sfc_LINESTRING", "sfc_MULTILINESTRING", "sfc_POINT", "sfc_MULTIPOINT"))) {
+  if (
+    !(class(x[[sfc_name]])[[1]] %in%
+      c("sfc_LINESTRING", "sfc_MULTILINESTRING", "sfc_POINT", "sfc_MULTIPOINT"))
+  ) {
     chk::abort_chk("sfc_name '", sfc_name, "' must be point or linestring")
   }
 
-  if (class(x[[sfc_name]])[[1]] %in% c("sfc_LINESTRING", "sfc_MULTILINESTRING")) {
+  if (
+    class(x[[sfc_name]])[[1]] %in% c("sfc_LINESTRING", "sfc_MULTILINESTRING")
+  ) {
     x <- sf::st_cast(x, warn = FALSE, "POINT")
   }
-
 
   if (!sfc_name %in% check_is_sfc(x)) {
     chk::abort_chk("sfc_name '", sfc_name, "' is not an sfc column")

--- a/R/list.R
+++ b/R/list.R
@@ -1,10 +1,12 @@
-list_files <- function(x_name,
-                       class,
-                       sub,
-                       main,
-                       recursive,
-                       include_root,
-                       ext = "rds") {
+list_files <- function(
+  x_name,
+  class,
+  sub,
+  main,
+  recursive,
+  include_root,
+  ext = "rds"
+) {
   chk_string(x_name)
   chk_character(sub)
   chk_range(length(sub))
@@ -25,7 +27,9 @@ list_files <- function(x_name,
   names(files) <- file.path(dir, files)
   files <- sub(ext, "", files)
   files <- files[grepl(x_name, basename(files))]
-  if (!include_root) files <- files[grepl("/", files)]
+  if (!include_root) {
+    files <- files[grepl("/", files)]
+  }
   names <- file_path(class, sub, files)
   files <- names(files)
   if (length(files)) {
@@ -46,16 +50,24 @@ list_files <- function(x_name,
 #' @param ext A string of the file extension.
 #' @family list functions
 #' @export
-sbf_list_objects <- function(x_name = ".*", sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             recursive = FALSE, include_root = TRUE,
-                             ext = "rds") {
+sbf_list_objects <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "rds"
+) {
   chk_string(ext)
   chk_subset(ext, "rds")
-  list_files(x_name, "objects",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "objects",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -67,16 +79,24 @@ sbf_list_objects <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_datas <- function(x_name = ".*", sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           recursive = FALSE, include_root = TRUE,
-                           ext = "rds") {
+sbf_list_datas <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "rds"
+) {
   chk_string(ext)
   chk_subset(ext, "rds")
-  list_files(x_name, "data",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "data",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -88,16 +108,24 @@ sbf_list_datas <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_tables <- function(x_name = ".*", sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            recursive = FALSE, include_root = TRUE,
-                            ext = "rds") {
+sbf_list_tables <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "rds"
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "csv"))
-  list_files(x_name, "tables",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "tables",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -110,16 +138,24 @@ sbf_list_tables <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_numbers <- function(x_name = ".*", sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             recursive = FALSE, include_root = TRUE,
-                             ext = "rds") {
+sbf_list_numbers <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "rds"
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "csv"))
-  list_files(x_name, "numbers",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "numbers",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -132,16 +168,24 @@ sbf_list_numbers <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_strings <- function(x_name = ".*", sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             recursive = FALSE, include_root = TRUE,
-                             ext = "rds") {
+sbf_list_strings <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "rds"
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "txt"))
-  list_files(x_name, "strings",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "strings",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -153,16 +197,24 @@ sbf_list_strings <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_blocks <- function(x_name = ".*", sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            recursive = FALSE, include_root = TRUE,
-                            ext = "rds") {
+sbf_list_blocks <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "rds"
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "txt"))
-  list_files(x_name, "blocks",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "blocks",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -174,16 +226,24 @@ sbf_list_blocks <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_plots <- function(x_name = ".*", sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           recursive = FALSE, include_root = TRUE,
-                           ext = "rds") {
+sbf_list_plots <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "rds"
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "png"))
-  list_files(x_name, "plots",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "plots",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -195,16 +255,24 @@ sbf_list_plots <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_windows <- function(x_name = ".*", sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             recursive = FALSE, include_root = TRUE,
-                             ext = "png") {
+sbf_list_windows <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "png"
+) {
   chk_string(ext)
   chk_subset(ext, "png")
-  list_files(x_name, "windows",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "windows",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }
 
@@ -216,15 +284,23 @@ sbf_list_windows <- function(x_name = ".*", sub = sbf_get_sub(),
 #' @inheritParams sbf_list_objects
 #' @family list functions
 #' @export
-sbf_list_dbs <- function(x_name = ".*", sub = sbf_get_sub(),
-                         main = sbf_get_main(),
-                         recursive = FALSE, include_root = TRUE,
-                         ext = "sqlite") {
+sbf_list_dbs <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  recursive = FALSE,
+  include_root = TRUE,
+  ext = "sqlite"
+) {
   chk_string(ext)
   chk_subset(ext, "sqlite")
-  list_files(x_name, "dbs",
-    sub = sub, main = main,
+  list_files(
+    x_name,
+    "dbs",
+    sub = sub,
+    main = main,
     recursive = recursive,
-    include_root = include_root, ext = ext
+    include_root = include_root,
+    ext = ext
   )
 }

--- a/R/load.R
+++ b/R/load.R
@@ -1,20 +1,20 @@
 load_rds <- function(x_name, class, sub, main, fun = NULL, exists = TRUE) {
   path <- get_path(x_name, class, sub, main, ext = "rds", exists = exists)
-  
+
   if (!vld_file(path)) {
     return(NULL)
   }
   object <- readRDS(path)
-  
+
   if (!is.null(fun)) {
     object <- fun(object)
   }
-  
+
   if (class == "spatial") {
     valid <- valid_spatial(object)
     if (!valid) wrn(backtick_chk(x_name), "is not a valid spatial object.")
   }
-  
+
   object
 }
 
@@ -25,10 +25,12 @@ load_rds <- function(x_name, class, sub, main, fun = NULL, exists = TRUE) {
 #' @return An R object or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_object <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            exists = TRUE) {
+sbf_load_object <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "objects", sub = sub, main = main, exists = exists)
 }
 
@@ -39,10 +41,12 @@ sbf_load_object <- function(x_name,
 #' @return A data frame or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_data <- function(x_name,
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main(),
-                          exists = TRUE) {
+sbf_load_data <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "data", sub = sub, main = main, exists = exists)
 }
 
@@ -54,10 +58,12 @@ sbf_load_data <- function(x_name,
 #' @return An sf tbl or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_spatial <- function(x_name,
-                             sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             exists = TRUE) {
+sbf_load_spatial <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "spatial", sub = sub, main = main, exists = exists)
 }
 
@@ -68,10 +74,12 @@ sbf_load_spatial <- function(x_name,
 #' @return A number or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_number <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            exists = TRUE) {
+sbf_load_number <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "numbers", sub = sub, main = main, exists = exists)
 }
 
@@ -82,10 +90,12 @@ sbf_load_number <- function(x_name,
 #' @return A string or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_string <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            exists = TRUE) {
+sbf_load_string <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "strings", sub = sub, main = main, exists = exists)
 }
 
@@ -96,10 +106,12 @@ sbf_load_string <- function(x_name,
 #' @return A code block or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_block <- function(x_name,
-                           sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           exists = TRUE) {
+sbf_load_block <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "blocks", sub = sub, main = main, exists = exists)
 }
 
@@ -110,10 +122,12 @@ sbf_load_block <- function(x_name,
 #' @return A data frame or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_table <- function(x_name,
-                           sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           exists = TRUE) {
+sbf_load_table <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "tables", sub = sub, main = main, exists = exists)
 }
 
@@ -124,10 +138,12 @@ sbf_load_table <- function(x_name,
 #' @return A ggplot object or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_plot <- function(x_name,
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main(),
-                          exists = TRUE) {
+sbf_load_plot <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
   load_rds(x_name, class = "plots", sub = sub, main = main, exists = exists)
 }
 
@@ -138,16 +154,19 @@ sbf_load_plot <- function(x_name,
 #' @return A data.frame or NULL if doesn't exist.
 #' @family load functions
 #' @export
-sbf_load_plot_data <- function(x_name,
-                               sub = sbf_get_sub(),
-                               main = sbf_get_main(),
-                               exists = TRUE) {
-  load_rds(x_name,
-           class = "plots",
-           sub = sub,
-           main = main,
-           fun = get_plot_data,
-           exists = exists
+sbf_load_plot_data <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE
+) {
+  load_rds(
+    x_name,
+    class = "plots",
+    sub = sub,
+    main = main,
+    fun = get_plot_data,
+    exists = exists
   )
 }
 
@@ -160,16 +179,18 @@ sbf_load_plot_data <- function(x_name,
 #' @return A data.frame of the table.
 #' @family load functions
 #' @export
-sbf_load_data_from_db <- function(x_name,
-                                  db_name = sbf_get_db_name(),
-                                  sub = sbf_get_sub(),
-                                  main = sbf_get_main()) {
+sbf_load_data_from_db <- function(
+  x_name,
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   chk_string(x_name)
   chk_string(db_name)
-  
+
   conn <- sbf_open_db(db_name, sub = sub, main = main)
   on.exit(sbf_close_db(conn))
-  
+
   rws_read_table(x_name, conn = conn)
 }
 
@@ -180,12 +201,14 @@ sbf_load_data_from_db <- function(x_name,
 #' @return A data.frame of the table.
 #' @family load functions
 #' @export
-sbf_load_db_metatable <- function(db_name = sbf_get_db_name(),
-                                  sub = sbf_get_sub(),
-                                  main = sbf_get_main()) {
+sbf_load_db_metatable <- function(
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   conn <- sbf_open_db(db_name, sub = sub, main = main)
   on.exit(sbf_close_db(conn))
-  
+
   db_metatable_from_connection(conn)
 }
 
@@ -193,16 +216,16 @@ load_rdss <- function(class, sub, main, env, rename, fun = NULL) {
   chk_character(sub)
   chk_range(length(sub))
   chk_string(main)
-  
+
   chk_s3_class(env, "environment")
   chk_function(rename)
-  
+
   sub <- sanitize_path(sub)
   main <- sanitize_path(main, rm_leading = FALSE)
-  
+
   path <- file_path(main, class, sub)
   files <- tools::list_files_with_exts(path, "rds")
-  
+
   if (!length(files)) {
     warning("no ", class, " to load")
     return(invisible(character(0)))
@@ -210,12 +233,12 @@ load_rdss <- function(class, sub, main, env, rename, fun = NULL) {
   names <- tools::file_path_sans_ext(basename(files))
   for (i in seq_along(files)) {
     object <- readRDS(files[i])
-    
+
     if (class == "spatial") {
       valid <- valid_spatial(object)
       if (!valid) wrn(backtick_chk(names[i]), "is not a valid spatial object.")
     }
-    
+
     if (!is.null(fun)) {
       object <- fun(object)
     }
@@ -234,10 +257,12 @@ load_rdss <- function(class, sub, main, env, rename, fun = NULL) {
 #' @return A invisble character vector of the objects' names.
 #' @family load functions
 #' @export
-sbf_load_objects <- function(sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             rename = identity,
-                             env = parent.frame()) {
+sbf_load_objects <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   load_rdss("objects", sub = sub, main = main, env = env, rename = rename)
 }
 
@@ -248,10 +273,12 @@ sbf_load_objects <- function(sub = sbf_get_sub(),
 #' @return A invisble character vector of the data frames' names.
 #' @family load functions
 #' @export
-sbf_load_datas <- function(sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           rename = identity,
-                           env = parent.frame()) {
+sbf_load_datas <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   load_rdss("data", sub = sub, main = main, env = env, rename = rename)
 }
 
@@ -263,10 +290,12 @@ sbf_load_datas <- function(sub = sbf_get_sub(),
 #' @return A invisble character vector of the data frames' names.
 #' @family load functions
 #' @export
-sbf_load_spatials <- function(sub = sbf_get_sub(),
-                              main = sbf_get_main(),
-                              rename = identity,
-                              env = parent.frame()) {
+sbf_load_spatials <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   load_rdss("spatial", sub = sub, main = main, env = env, rename = rename)
 }
 
@@ -277,10 +306,12 @@ sbf_load_spatials <- function(sub = sbf_get_sub(),
 #' @return A invisble character vector of the data frames' names.
 #' @family load functions
 #' @export
-sbf_load_tables <- function(sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            rename = identity,
-                            env = parent.frame()) {
+sbf_load_tables <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   load_rdss("tables", sub = sub, main = main, env = env, rename = rename)
 }
 
@@ -291,10 +322,12 @@ sbf_load_tables <- function(sub = sbf_get_sub(),
 #' @return A invisble character vector of the numbers' names.
 #' @family load functions
 #' @export
-sbf_load_numbers <- function(sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             rename = identity,
-                             env = parent.frame()) {
+sbf_load_numbers <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   load_rdss("numbers", sub = sub, main = main, env = env, rename = rename)
 }
 
@@ -305,10 +338,12 @@ sbf_load_numbers <- function(sub = sbf_get_sub(),
 #' @return A invisble character vector of the string' names.
 #' @family load functions
 #' @export
-sbf_load_strings <- function(sub = sbf_get_sub(),
-                             main = sbf_get_main(),
-                             rename = identity,
-                             env = parent.frame()) {
+sbf_load_strings <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   load_rdss("strings", sub = sub, main = main, env = env, rename = rename)
 }
 
@@ -319,10 +354,12 @@ sbf_load_strings <- function(sub = sbf_get_sub(),
 #' @return A invisble character vector of the blocks' names.
 #' @family load functions
 #' @export
-sbf_load_blocks <- function(sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            rename = identity,
-                            env = parent.frame()) {
+sbf_load_blocks <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   load_rdss("blocks", sub = sub, main = main, env = env, rename = rename)
 }
 
@@ -333,13 +370,19 @@ sbf_load_blocks <- function(sub = sbf_get_sub(),
 #' @return A invisble character vector of the plots' names.
 #' @family load functions
 #' @export
-sbf_load_plots_data <- function(sub = sbf_get_sub(),
-                                main = sbf_get_main(),
-                                rename = identity,
-                                env = parent.frame()) {
-  load_rdss("plots",
-            sub = sub, main = main, env = env, rename = rename,
-            fun = get_plot_data
+sbf_load_plots_data <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
+  load_rdss(
+    "plots",
+    sub = sub,
+    main = main,
+    env = env,
+    rename = rename,
+    fun = get_plot_data
   )
 }
 
@@ -352,17 +395,19 @@ sbf_load_plots_data <- function(sub = sbf_get_sub(),
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family load functions
 #' @export
-sbf_load_datas_from_db <- function(db_name = sbf_get_db_name(),
-                                   sub = sbf_get_sub(),
-                                   main = sbf_get_main(),
-                                   rename = identity,
-                                   env = parent.frame()) {
+sbf_load_datas_from_db <- function(
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  rename = identity,
+  env = parent.frame()
+) {
   chk_s3_class(env, "environment")
   chk_function(rename)
-  
+
   conn <- sbf_open_db(db_name, sub = sub, main = main)
   on.exit(sbf_close_db(conn))
-  
+
   datas <- rws_read(conn)
   names(datas) <- rename(names(datas))
   mapply(assign, names(datas), datas, MoreArgs = list(envir = env))
@@ -388,16 +433,18 @@ sbf_load_datas_from_db <- function(db_name = sbf_get_db_name(),
 #' @return a tibble of the loaded objects
 #' @family load functions
 #' @keywords internal
-load_rdss_recursive <- function(x_name = ".*",
-                                class,
-                                sub = sbf_get_sub(),
-                                main = sbf_get_main(),
-                                include_root = TRUE,
-                                tag = ".*",
-                                meta = FALSE,
-                                drop = NULL,
-                                fun = NULL,
-                                ext = "rds") {
+load_rdss_recursive <- function(
+  x_name = ".*",
+  class,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL,
+  fun = NULL,
+  ext = "rds"
+) {
   chk_string(x_name)
   chk_character(sub)
   chk_range(length(sub))
@@ -408,7 +455,7 @@ load_rdss_recursive <- function(x_name = ".*",
   chk_null_or(drop, vld = vld_character)
   chk_character(ext)
 
-  if(!is.null(drop)) {
+  if (!is.null(drop)) {
     chk::chk_not_any_na(drop)
   }
 
@@ -418,9 +465,9 @@ load_rdss_recursive <- function(x_name = ".*",
 
   sub <- sanitize_path(sub)
   main <- sanitize_path(main, rm_leading = FALSE)
-  
+
   dir <- file_path(main, class, sub)
-  
+
   ext <- p0("[.](", p(ext, collapse = "|"), ")$")
 
   files <- list.files(dir, pattern = ext, recursive = TRUE)
@@ -431,8 +478,10 @@ load_rdss_recursive <- function(x_name = ".*",
   keep <- !duplicated(files)
   files <- files[keep]
   files <- files[grepl(x_name, basename(files))]
-  if (!include_root) files <- files[grepl("/", files)]
-  
+  if (!include_root) {
+    files <- files[grepl("/", files)]
+  }
+
   if (!length(files)) {
     data <- tibble(x = I(list()))
     class(data$x) <- "list"
@@ -442,12 +491,14 @@ load_rdss_recursive <- function(x_name = ".*",
     data$file <- character(0)
     return(data)
   }
-  
-  if(length(drop) > 0) {
-    drop <- purrr::map_lgl(path_split(files), \(x) length(intersect(x, drop)) > 0)
+
+  if (length(drop) > 0) {
+    drop <- purrr::map_lgl(path_split(files), \(x) {
+      length(intersect(x, drop)) > 0
+    })
     files <- files[!drop]
   }
-  
+
   if (read) {
     objects <- lapply(names(files), readRDS)
   } else {
@@ -456,7 +507,7 @@ load_rdss_recursive <- function(x_name = ".*",
   if (!is.null(fun)) {
     objects <- lapply(objects, fun)
   }
-  
+
   data <- data.frame(x = I(objects))
   names(data) <- class
   if (length(files) > 0) {
@@ -465,48 +516,54 @@ load_rdss_recursive <- function(x_name = ".*",
     data <- tibble(objects = list(), name = "", sub = "", file = "")
     colnames(data)[1] <- class
   }
-  
+
   is_tag <- rep(TRUE, nrow(data))
   if (tag != ".*") {
     is_tag <- grepl(tag, meta_columns(names(files))$tag)
   }
-  
-  if (meta) data <- cbind(data, meta_columns(names(files)))
-  
+
+  if (meta) {
+    data <- cbind(data, meta_columns(names(files)))
+  }
+
   data <- data[is_tag, ]
   class(data[[1]]) <- "list"
   as_tibble(data)
 }
 
-subs_rds_recursive <- function(x_name,
-                               class,
-                               sub,
-                               main,
-                               include_root,
-                               ext = "rds") {
+subs_rds_recursive <- function(
+  x_name,
+  class,
+  sub,
+  main,
+  include_root,
+  ext = "rds"
+) {
   chk_string(x_name)
   chk_character(sub)
   chk_range(length(sub))
   chk_string(main)
   chk_flag(include_root)
-  
+
   sub <- sanitize_path(sub)
   main <- sanitize_path(main, rm_leading = FALSE)
-  
+
   dir <- file_path(main, class, sub)
-  
+
   ext <- p0("[.]", ext, "$")
   files <- list.files(dir, pattern = p0("^", x_name, ext), recursive = TRUE)
- 
+
   names(files) <- file.path(dir, files)
   files <- sub(ext, "", files)
   files <- files[basename(files) == x_name]
-  if (!include_root) files <- files[grepl("/", files)]
-  
+  if (!include_root) {
+    files <- files[grepl("/", files)]
+  }
+
   if (!length(files)) {
     return(character(0))
   }
-  
+
   subfolder_columns(files)$sub
 }
 
@@ -523,14 +580,20 @@ subs_rds_recursive <- function(x_name,
 #' sub folder.
 #' @family load functions
 #' @export
-sbf_load_objects_recursive <- function(x_name = ".*",
-                                       sub = sbf_get_sub(),
-                                       main = sbf_get_main(),
-                                       include_root = TRUE,
-                                       drop = NULL) {
-  load_rdss_recursive(x_name, "objects",
-                      sub = sub, main = main,
-                      include_root = include_root, drop = drop
+sbf_load_objects_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  drop = NULL
+) {
+  load_rdss_recursive(
+    x_name,
+    "objects",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    drop = drop
   )
 }
 
@@ -545,14 +608,20 @@ sbf_load_objects_recursive <- function(x_name = ".*",
 #' @inheritParams sbf_load_objects_recursive
 #' @family load functions
 #' @export
-sbf_load_datas_recursive <- function(x_name = ".*",
-                                     sub = sbf_get_sub(),
-                                     main = sbf_get_main(),
-                                     include_root = TRUE,
-                                     drop = NULL) {
-  data <- load_rdss_recursive(x_name, "data",
-                              sub = sub, main = main,
-                              include_root = include_root, drop = drop
+sbf_load_datas_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  drop = NULL
+) {
+  data <- load_rdss_recursive(
+    x_name,
+    "data",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    drop = drop
   )
   data
 }
@@ -572,17 +641,24 @@ sbf_load_datas_recursive <- function(x_name = ".*",
 #' other metadata as columns.
 #' @family load functions
 #' @export
-sbf_load_numbers_recursive <- function(x_name = ".*",
-                                       sub = sbf_get_sub(),
-                                       main = sbf_get_main(),
-                                       include_root = TRUE,
-                                       tag = ".*",
-                                       meta = FALSE,
-                                       drop = NULL) {
-  data <- load_rdss_recursive(x_name, "numbers",
-                              sub = sub, main = main,
-                              include_root = include_root, tag = tag,
-                              meta = meta, drop = drop
+sbf_load_numbers_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL
+) {
+  data <- load_rdss_recursive(
+    x_name,
+    "numbers",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    tag = tag,
+    meta = meta,
+    drop = drop
   )
   data[1] <- unname(unlist(data[1]))
   data
@@ -603,17 +679,24 @@ sbf_load_numbers_recursive <- function(x_name = ".*",
 #' other metadata as columns.
 #' @family load functions
 #' @export
-sbf_load_strings_recursive <- function(x_name = ".*",
-                                       sub = sbf_get_sub(),
-                                       main = sbf_get_main(),
-                                       include_root = TRUE,
-                                       tag = ".*",
-                                       meta = FALSE,
-                                       drop = NULL) {
-  data <- load_rdss_recursive(x_name, "strings",
-                              sub = sub, main = main,
-                              include_root = include_root, tag = tag,
-                              meta = meta, drop = drop
+sbf_load_strings_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL
+) {
+  data <- load_rdss_recursive(
+    x_name,
+    "strings",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    tag = tag,
+    meta = meta,
+    drop = drop
   )
   if (nrow(data)) {
     data[1] <- unname(unlist(data[1]))
@@ -638,17 +721,24 @@ sbf_load_strings_recursive <- function(x_name = ".*",
 #' other metadata as columns.
 #' @family load functions
 #' @export
-sbf_load_tables_recursive <- function(x_name = ".*",
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main(),
-                                      include_root = TRUE,
-                                      tag = ".*",
-                                      meta = FALSE,
-                                      drop = NULL) {
-  load_rdss_recursive(x_name, "tables",
-                      sub = sub, main = main,
-                      include_root = include_root, tag = tag, meta = meta,
-                      drop = drop
+sbf_load_tables_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL
+) {
+  load_rdss_recursive(
+    x_name,
+    "tables",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    tag = tag,
+    meta = meta,
+    drop = drop
   )
 }
 
@@ -665,17 +755,24 @@ sbf_load_tables_recursive <- function(x_name = ".*",
 #' @inheritParams sbf_load_tables_recursive
 #' @family load functions
 #' @export
-sbf_load_blocks_recursive <- function(x_name = ".*",
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main(),
-                                      include_root = TRUE,
-                                      tag = ".*",
-                                      meta = FALSE,
-                                      drop = NULL) {
-  data <- load_rdss_recursive(x_name, "blocks",
-                              sub = sub, main = main,
-                              include_root = include_root, tag = tag,
-                              meta = meta, drop = drop
+sbf_load_blocks_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL
+) {
+  data <- load_rdss_recursive(
+    x_name,
+    "blocks",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    tag = tag,
+    meta = meta,
+    drop = drop
   )
   data[1] <- unname(unlist(data[1]))
   data
@@ -693,17 +790,24 @@ sbf_load_blocks_recursive <- function(x_name = ".*",
 #' @inheritParams sbf_load_tables_recursive
 #' @family load functions
 #' @export
-sbf_load_plots_recursive <- function(x_name = ".*",
-                                     sub = sbf_get_sub(),
-                                     main = sbf_get_main(),
-                                     include_root = TRUE,
-                                     tag = ".*",
-                                     meta = FALSE,
-                                     drop = NULL) {
-  load_rdss_recursive(x_name, "plots",
-                      sub = sub, main = main,
-                      include_root = include_root, tag = tag, meta = meta,
-                      drop = drop
+sbf_load_plots_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL
+) {
+  load_rdss_recursive(
+    x_name,
+    "plots",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    tag = tag,
+    meta = meta,
+    drop = drop
   )
 }
 
@@ -720,18 +824,25 @@ sbf_load_plots_recursive <- function(x_name = ".*",
 #' @inheritParams sbf_load_tables_recursive
 #' @family load functions
 #' @export
-sbf_load_plots_data_recursive <- function(x_name = ".*",
-                                          sub = sbf_get_sub(),
-                                          main = sbf_get_main(),
-                                          include_root = TRUE,
-                                          tag = ".*",
-                                          meta = FALSE,
-                                          drop = NULL) {
-  data <- load_rdss_recursive(x_name, "plots",
-                              sub = sub, main = main,
-                              include_root = include_root, tag = tag,
-                              meta = meta, fun = get_plot_data,
-                              drop = drop
+sbf_load_plots_data_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL
+) {
+  data <- load_rdss_recursive(
+    x_name,
+    "plots",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    tag = tag,
+    meta = meta,
+    fun = get_plot_data,
+    drop = drop
   )
   names(data)[1] <- "plots_data"
   data
@@ -750,17 +861,25 @@ sbf_load_plots_data_recursive <- function(x_name = ".*",
 #' @inheritParams sbf_load_tables_recursive
 #' @family load functions
 #' @export
-sbf_load_windows_recursive <- function(x_name = ".*",
-                                       sub = sbf_get_sub(),
-                                       main = sbf_get_main(),
-                                       include_root = TRUE,
-                                       tag = ".*",
-                                       meta = FALSE,
-                                       drop = NULL) {
-  data <- load_rdss_recursive(x_name, "windows",
-                              sub = sub, main = main,
-                              include_root = include_root, tag = tag,
-                              meta = meta, ext = c("yaml", "rda"), drop = drop
+sbf_load_windows_recursive <- function(
+  x_name = ".*",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE,
+  tag = ".*",
+  meta = FALSE,
+  drop = NULL
+) {
+  data <- load_rdss_recursive(
+    x_name,
+    "windows",
+    sub = sub,
+    main = main,
+    include_root = include_root,
+    tag = tag,
+    meta = meta,
+    ext = c("yaml", "rda"),
+    drop = drop
   )
   data$file <- replace_ext(data$file, "png")
   data$windows <- data$file
@@ -775,13 +894,18 @@ sbf_load_windows_recursive <- function(x_name = ".*",
 #' @inheritParams sbf_load_objects_recursive
 #' @family load functions
 #' @export
-sbf_subs_object_recursive <- function(x_name,
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main(),
-                                      include_root = TRUE) {
-  subs_rds_recursive(x_name, "objects",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_object_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "objects",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
 
@@ -793,13 +917,18 @@ sbf_subs_object_recursive <- function(x_name,
 #' @inheritParams sbf_subs_object_recursive
 #' @family load functions
 #' @export
-sbf_subs_data_recursive <- function(x_name,
-                                    sub = sbf_get_sub(),
-                                    main = sbf_get_main(),
-                                    include_root = TRUE) {
-  subs_rds_recursive(x_name, "data",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_data_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "data",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
 
@@ -811,13 +940,18 @@ sbf_subs_data_recursive <- function(x_name,
 #' @inheritParams sbf_subs_object_recursive
 #' @family load functions
 #' @export
-sbf_subs_number_recursive <- function(x_name,
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main(),
-                                      include_root = TRUE) {
-  subs_rds_recursive(x_name, "numbers",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_number_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "numbers",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
 
@@ -829,13 +963,18 @@ sbf_subs_number_recursive <- function(x_name,
 #' @inheritParams sbf_subs_object_recursive
 #' @family load functions
 #' @export
-sbf_subs_string_recursive <- function(x_name,
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main(),
-                                      include_root = TRUE) {
-  subs_rds_recursive(x_name, "strings",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_string_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "strings",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
 
@@ -847,13 +986,18 @@ sbf_subs_string_recursive <- function(x_name,
 #' @inheritParams sbf_subs_object_recursive
 #' @family load functions
 #' @export
-sbf_subs_block_recursive <- function(x_name,
-                                     sub = sbf_get_sub(),
-                                     main = sbf_get_main(),
-                                     include_root = TRUE) {
-  subs_rds_recursive(x_name, "blocks",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_block_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "blocks",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
 
@@ -865,13 +1009,18 @@ sbf_subs_block_recursive <- function(x_name,
 #' @inheritParams sbf_subs_object_recursive
 #' @family load functions
 #' @export
-sbf_subs_table_recursive <- function(x_name,
-                                     sub = sbf_get_sub(),
-                                     main = sbf_get_main(),
-                                     include_root = TRUE) {
-  subs_rds_recursive(x_name, "tables",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_table_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "tables",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
 
@@ -883,13 +1032,18 @@ sbf_subs_table_recursive <- function(x_name,
 #' @inheritParams sbf_subs_object_recursive
 #' @family load functions
 #' @export
-sbf_subs_plot_recursive <- function(x_name,
-                                    sub = sbf_get_sub(),
-                                    main = sbf_get_main(),
-                                    include_root = TRUE) {
-  subs_rds_recursive(x_name, "plots",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_plot_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "plots",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
 
@@ -901,13 +1055,17 @@ sbf_subs_plot_recursive <- function(x_name,
 #' @inheritParams sbf_subs_object_recursive
 #' @family load functions
 #' @export
-sbf_subs_window_recursive <- function(x_name,
-                                      sub = sbf_get_sub(),
-                                      main = sbf_get_main(),
-                                      include_root = TRUE) {
-  subs_rds_recursive(x_name, "windows",
-                     sub = sub, main = main,
-                     include_root = include_root
+sbf_subs_window_recursive <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  include_root = TRUE
+) {
+  subs_rds_recursive(
+    x_name,
+    "windows",
+    sub = sub,
+    main = main,
+    include_root = include_root
   )
 }
-

--- a/R/main.R
+++ b/R/main.R
@@ -24,7 +24,9 @@ sbf_set_main <- function(..., rm = FALSE, ask = getOption("sbf.ask", TRUE)) {
   path <- file_path(..., collapse = TRUE)
   path <- sanitize_path(path, rm_leading = FALSE)
   options(sbf.main = path)
-  if (rm) rm_all(ask = ask)
+  if (rm) {
+    rm_all(ask = ask)
+  }
   invisible(path)
 }
 
@@ -48,8 +50,10 @@ sbf_reset_main <- function(rm = FALSE, ask = getOption("sbf.ask", TRUE)) {
 #' @family reset
 #' @family housekeeping functions
 #' @export
-sbf_rm_main <- function(main = sbf_get_main(),
-                        ask = getOption("sbf.ask", TRUE)) {
+sbf_rm_main <- function(
+  main = sbf_get_main(),
+  ask = getOption("sbf.ask", TRUE)
+) {
   chk_flag(ask)
   chk_string(main)
 

--- a/R/open.R
+++ b/R/open.R
@@ -8,11 +8,13 @@
 #' @param height A positive number indicating the height in inches.
 #' @family graphic functions
 #' @export
-sbf_open_pdf <- function(x_name = "plots",
-                         sub = sbf_get_sub(),
-                         main = sbf_get_main(),
-                         width = 6,
-                         height = width) {
+sbf_open_pdf <- function(
+  x_name = "plots",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  width = 6,
+  height = width
+) {
   chk_string(x_name)
   chk_gt(nchar(x_name))
   chk_character(sub)
@@ -55,22 +57,28 @@ sbf_open_pdf <- function(x_name = "plots",
 #' @param tag A string of the tag. Deprecated.
 #' @family database functions
 #' @export
-sbf_open_db <- function(db_name = sbf_get_db_name(),
-                        sub = sbf_get_sub(),
-                        main = sbf_get_main(),
-                        exists = TRUE,
-                        caption = NULL,
-                        report = NA,
-                        tag = NULL,
-                        ask = getOption("sbf.ask", TRUE)) {
+sbf_open_db <- function(
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  exists = TRUE,
+  caption = NULL,
+  report = NA,
+  tag = NULL,
+  ask = getOption("sbf.ask", TRUE)
+) {
   chk_string(db_name)
   chk_character(sub)
   chk_range(length(sub))
   chk_string(main)
   chk_lgl(exists)
   chk_lgl(report)
-  if (!is.null(caption)) chk_string(caption)
-  if (!is.null(tag)) chk_string(tag)
+  if (!is.null(caption)) {
+    chk_string(caption)
+  }
+  if (!is.null(tag)) {
+    chk_string(tag)
+  }
 
   if (!missing(caption)) {
     lifecycle::deprecate_stop("0.0.0.9039", "sbf_open_db(caption = )")
@@ -87,7 +95,9 @@ sbf_open_db <- function(db_name = sbf_get_db_name(),
 
   file <- file_name(main, "dbs", sub, db_name, ext = "sqlite")
 
-  if (isTRUE(exists)) chk_file(file)
+  if (isTRUE(exists)) {
+    chk_file(file)
+  }
 
   if (isFALSE(exists) && file.exists(file)) {
     if (ask && !yesno("Delete file '", file, "'?")) {
@@ -109,7 +119,8 @@ sbf_open_db <- function(db_name = sbf_get_db_name(),
 #' @family graphic functions
 #' @export
 sbf_open_window <- function(width = 6, height = width) {
-  fun <- switch(Sys.info()["sysname"],
+  fun <- switch(
+    Sys.info()["sysname"],
     Windows = grDevices::windows,
     Darwin = grDevices::quartz,
     grDevices::x11

--- a/R/params.R
+++ b/R/params.R
@@ -8,7 +8,7 @@
 #' A string is a non-missing character scalar.
 #
 #' @inheritParams rlang::args_dots_empty
-#' @param drop A character vector specifying the names of sub folders 
+#' @param drop A character vector specifying the names of sub folders
 #' and files to drop or `NULL` (the default).
 ## add parameter descriptions here
 #' @keywords internal

--- a/R/path.R
+++ b/R/path.R
@@ -1,6 +1,7 @@
 get_path <- function(x_name, class, sub, main, ext, exists) {
   chk_lgl(exists)
-  path <- create_file_path(x_name,
+  path <- create_file_path(
+    x_name,
     class = class,
     sub = sub,
     main = main,
@@ -19,14 +20,17 @@ get_path <- function(x_name, class, sub, main, ext, exists) {
 #' @param exists A logical scalar specifying whether the file should exist.
 #' @return A string indicating the path.
 #' @export
-sbf_path_object <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            ext = "rds",
-                            exists = NA) {
+sbf_path_object <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "rds",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, "rds")
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "objects",
     sub = sub,
     main = main,
@@ -41,14 +45,17 @@ sbf_path_object <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_data <- function(x_name,
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main(),
-                          ext = "rds",
-                          exists = NA) {
+sbf_path_data <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "rds",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, "rds")
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "data",
     sub = sub,
     main = main,
@@ -63,14 +70,17 @@ sbf_path_data <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_number <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            ext = "rds",
-                            exists = NA) {
+sbf_path_number <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "rds",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "csv"))
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "numbers",
     sub = sub,
     main = main,
@@ -85,14 +95,17 @@ sbf_path_number <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_string <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            ext = "rds",
-                            exists = NA) {
+sbf_path_string <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "rds",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "txt"))
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "strings",
     sub = sub,
     main = main,
@@ -107,14 +120,17 @@ sbf_path_string <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_block <- function(x_name,
-                           sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           ext = "rds",
-                           exists = NA) {
+sbf_path_block <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "rds",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "txt"))
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "blocks",
     sub = sub,
     main = main,
@@ -129,14 +145,17 @@ sbf_path_block <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_table <- function(x_name,
-                           sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           ext = "rds",
-                           exists = NA) {
+sbf_path_table <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "rds",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "csv"))
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "tables",
     sub = sub,
     main = main,
@@ -151,14 +170,17 @@ sbf_path_table <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_plot <- function(x_name,
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main(),
-                          ext = "rds",
-                          exists = NA) {
+sbf_path_plot <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "rds",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, c("rds", "png"))
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "plots",
     sub = sub,
     main = main,
@@ -173,14 +195,17 @@ sbf_path_plot <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_window <- function(x_name,
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            ext = "png",
-                            exists = NA) {
+sbf_path_window <- function(
+  x_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "png",
+  exists = NA
+) {
   chk_string(ext)
   chk_subset(ext, "png")
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "windows",
     sub = sub,
     main = main,
@@ -195,13 +220,16 @@ sbf_path_window <- function(x_name,
 #' @inheritParams sbf_path_object
 #' @return A string indicating the path.
 #' @export
-sbf_path_db <- function(x_name = sbf_get_db_name(),
-                        sub = sbf_get_sub(),
-                        main = sbf_get_main(),
-                        ext = "sqlite",
-                        exists = NA) {
+sbf_path_db <- function(
+  x_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ext = "sqlite",
+  exists = NA
+) {
   chk_string(ext)
-  get_path(x_name,
+  get_path(
+    x_name,
     class = "dbs",
     sub = sub,
     main = main,

--- a/R/pg.R
+++ b/R/pg.R
@@ -24,8 +24,10 @@
 #' sbf_open_pg(config_path = "config.yml", config_value = "database")
 #' sbf_close_pg(conn)
 #' }
-sbf_open_pg <- function(config_path = getOption("psql.config_path", NULL),
-                        config_value = getOption("psql.config_value", "default")) {
+sbf_open_pg <- function(
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_open_pg()",
@@ -88,11 +90,13 @@ sbf_close_pg <- function(conn) {
 #'
 #' sbf_backup_pg("database-22")
 #' }
-sbf_backup_pg <- function(db_dump_name = sbf_get_db_name(),
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main(),
-                          config_path = getOption("psql.config_path", NULL),
-                          config_value = getOption("psql.config_value", "default")) {
+sbf_backup_pg <- function(
+  db_dump_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_backup_pg()",
@@ -121,9 +125,11 @@ sbf_backup_pg <- function(db_dump_name = sbf_get_db_name(),
 #' sbf_create_pg("new_database")
 #' sbf_create_pg("new_database", config_path = "keys/config.yml")
 #' }
-sbf_create_pg <- function(dbname,
-                          config_path = getOption("psql.config_path", NULL),
-                          config_value = getOption("psql.config_value", "default")) {
+sbf_create_pg <- function(
+  dbname,
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_create_pg()",
@@ -158,9 +164,11 @@ sbf_create_pg <- function(dbname,
 #'   comment TEXT)"
 #' )
 #' }
-sbf_execute_pg <- function(sql,
-                           config_path = getOption("psql.config_path", NULL),
-                           config_value = getOption("psql.config_value", "default")) {
+sbf_execute_pg <- function(
+  sql,
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_execute_pg()",
@@ -191,9 +199,11 @@ sbf_execute_pg <- function(sql,
 #' )
 #' sbf_list_tables_pg()
 #' }
-sbf_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
-                               config_path = getOption("psql.config_path", NULL),
-                               config_value = getOption("psql.config_value", "default")) {
+sbf_list_tables_pg <- function(
+  schema = getOption("psql.schema", "public"),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_list_tables_pg()",
@@ -224,10 +234,12 @@ sbf_list_tables_pg <- function(schema = getOption("psql.schema", "public"),
 #' sbf_load_data_from_pg("capture")
 #' sbf_load_data_from_pg("counts", "boat_count")
 #' }
-sbf_load_data_from_pg <- function(x,
-                                  schema = getOption("psql.schema", "public"),
-                                  config_path = getOption("psql.config_path", NULL),
-                                  config_value = getOption("psql.config_value", "default")) {
+sbf_load_data_from_pg <- function(
+  x,
+  schema = getOption("psql.schema", "public"),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_load_data_from_pg()",
@@ -258,11 +270,13 @@ sbf_load_data_from_pg <- function(x,
 #' sbf_load_datas_from_pg(schema = "capture")
 #' sbf_load_datas_from_pg(rename = toupper)
 #' }
-sbf_load_datas_from_pg <- function(schema = getOption("psql.schema", "public"),
-                                   rename = identity,
-                                   env = parent.frame(),
-                                   config_path = getOption("psql.config_path", NULL),
-                                   config_value = getOption("psql.config_value", "default")) {
+sbf_load_datas_from_pg <- function(
+  schema = getOption("psql.schema", "public"),
+  rename = identity,
+  env = parent.frame(),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_load_datas_from_pg()",
@@ -295,11 +309,13 @@ sbf_load_datas_from_pg <- function(schema = getOption("psql.schema", "public"),
 #' sbf_save_data_to_pg(outing, "creel")
 #' sbf_save_data_to_pg(outing_new, "creel", "outing")
 #' }
-sbf_save_data_to_pg <- function(x,
-                                x_name = NULL,
-                                schema = getOption("psql.schema", "public"),
-                                config_path = getOption("psql.config_path", NULL),
-                                config_value = getOption("psql.config_value", "default")) {
+sbf_save_data_to_pg <- function(
+  x,
+  x_name = NULL,
+  schema = getOption("psql.schema", "public"),
+  config_path = getOption("psql.config_path", NULL),
+  config_value = getOption("psql.config_value", "default")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_save_data_to_pg()",

--- a/R/print.R
+++ b/R/print.R
@@ -24,7 +24,13 @@ get_err_msg <- function() {
 #' @param plot A flag indicating whether or not to print the plot.
 #'
 #' @export
-sbf_print <- function(x, newpage = is.null(vp), vp = NULL, ntry = getOption("sbf.ntry", 3L), plot = getOption("sbf.plot", TRUE)) {
+sbf_print <- function(
+  x,
+  newpage = is.null(vp),
+  vp = NULL,
+  ntry = getOption("sbf.ntry", 3L),
+  plot = getOption("sbf.plot", TRUE)
+) {
   chk::chk_is(x, "ggplot")
   chk::chk_whole_number(ntry)
   chk::chk_gt(ntry)

--- a/R/query-db.R
+++ b/R/query-db.R
@@ -8,9 +8,12 @@
 #' @return A scalar numeric of the number of rows affected by the statement.
 #' @family database functions
 #' @export
-sbf_query_db <- function(sql, db_name = sbf_get_db_name(),
-                         sub = sbf_get_sub(),
-                         main = sbf_get_main()) {
+sbf_query_db <- function(
+  sql,
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   chk_string(sql)
   chk_gt(nchar(sql))
 

--- a/R/rm.R
+++ b/R/rm.R
@@ -22,8 +22,11 @@ rm_class <- function(sub, main, class, ask) {
 #' @return A invisible string of the directory deleted.
 #' @family housekeeping functions
 #' @export
-sbf_rm_flobs <- function(sub = sbf_get_sub(), main = sbf_get_main(),
-                         ask = getOption("sbf.ask", TRUE)) {
+sbf_rm_flobs <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  ask = getOption("sbf.ask", TRUE)
+) {
   chk_flag(ask)
 
   rm_class(sub = sub, main = main, class = "flobs", ask = ask)

--- a/R/save.R
+++ b/R/save.R
@@ -190,8 +190,12 @@ save_workbook <- function(x, sub, main, workbook_name, epgs) {
 #' @return An invisible string of the path to the saved object.
 #' @family save functions
 #' @export
-sbf_save_object <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
-                            main = sbf_get_main()) {
+sbf_save_object <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   x_name <- chk_deparse(x_name)
   chk_string(x_name)
   chk_gt(nchar(x_name))
@@ -212,8 +216,12 @@ sbf_save_object <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #' @return An invisible string of the path to the saved data.frame
 #' @family save functions
 #' @export
-sbf_save_data <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
-                          main = sbf_get_main()) {
+sbf_save_data <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   chk_s3_class(x, "data.frame")
   x_name <- chk_deparse(x_name)
   chk_string(x_name)
@@ -239,8 +247,12 @@ sbf_save_data <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #' @return An invisible string of the path to the saved data.frame
 #' @family save functions
 #' @export
-sbf_save_spatial <- function(x, x_name = NULL, sub = sbf_get_sub(),
-                             main = sbf_get_main()) {
+sbf_save_spatial <- function(
+  x,
+  x_name = NULL,
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   if (is.null(x_name)) {
     x_name <- chk::deparse_backtick_chk(substitute(x))
   }
@@ -283,7 +295,10 @@ check_spatial <- function(x, x_name = NULL) {
   index_name <- colnames(x)[1]
 
   if (index_name == geom_name) {
-    err(x_name, " must not have a first (index) column that is also the geometry column")
+    err(
+      x_name,
+      " must not have a first (index) column that is also the geometry column"
+    )
   }
 
   if (!chk::vld_not_any_na(x[[index_name]])) {
@@ -354,10 +369,16 @@ valid_spatial <- function(x) {
 #' @return An invisible string of the path to the saved object.
 #' @family save functions
 #' @export
-sbf_save_number <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
-                            main = sbf_get_main(), report = TRUE, tag = "",
-                            notes = "",
-                           signif = getOption("sbf.signif", 22)) {
+sbf_save_number <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  report = TRUE,
+  tag = "",
+  notes = "",
+  signif = getOption("sbf.signif", 22)
+) {
   x_name <- chk_deparse(x_name)
   chk_number(x)
   chk_string(x_name)
@@ -397,9 +418,15 @@ sbf_save_number <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #' @return An invisible string of the path to the saved object.
 #' @family save functions
 #' @export
-sbf_save_string <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
-                            main = sbf_get_main(), report = TRUE, tag = "",
-                            notes = "") {
+sbf_save_string <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  report = TRUE,
+  tag = "",
+  notes = ""
+) {
   x_name <- chk_deparse(x_name)
   chk_string(x)
   chk_string(x_name)
@@ -432,10 +459,16 @@ sbf_save_string <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #' @return An invisible string of the path to the saved object.
 #' @family save functions
 #' @export
-sbf_save_table <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           caption = "", report = TRUE, tag = "",
-                           notes = "") {
+sbf_save_table <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  caption = "",
+  report = TRUE,
+  tag = "",
+  notes = ""
+) {
   x_name <- chk_deparse(x_name)
   chk_s3_class(x, "data.frame")
   valid <- vapply(x, is_valid_table_column, TRUE)
@@ -475,10 +508,16 @@ sbf_save_table <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 #' @return An invisible string of the path to the saved object.
 #' @family save functions
 #' @export
-sbf_save_block <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           caption = "", report = TRUE, tag = "",
-                           notes = "") {
+sbf_save_block <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  caption = "",
+  report = TRUE,
+  tag = "",
+  notes = ""
+) {
   chk_string(x)
   chk_gt(nchar(x))
   x_name <- chk_deparse(x_name)
@@ -503,12 +542,12 @@ sbf_save_block <- function(x, x_name = substitute(x), sub = sbf_get_sub(),
 }
 
 #' Unstitch patches
-#' 
+#'
 #' Separates patches from a multi-panel plot created via `{patchwork}` into a
 #' list of the individual plots.
-#' 
+#'
 #' @param x An object of class `"ggplot"` and generally also `"patchwork"`.
-#' 
+#'
 #' @details
 #' Iteratively splits `patchwork` objects into smaller elements until a list of
 #' simple `ggplot` plots is created.
@@ -631,7 +670,7 @@ get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
 #'   geom_line(aes(mpg, cyl, color = cyl), mtcars) +
 #'   ggtitle("1")
 #' sbf_save_plot()
-#' 
+#'
 #' p_patches <-
 #'   ((ggplot(mtcars) +
 #'       geom_line(aes(mpg, cyl, color = cyl), mtcars) +
@@ -653,22 +692,31 @@ get_plot_layer_sheets <- function(p, prefix, csv, drop_uninformative_cols) {
 #' p_patches
 #' sbf_save_plot(p_patches)
 #' }
-#' 
-sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main(),
-                          caption = "", report = TRUE,
-                          tag = "",
-                          notes = "",
-                          units = "in",
-                          width = NA, height = width, dpi = 300,
-                          limitsize = TRUE,
-                          csv = 1000L,
-                          drop_uninformative_cols = TRUE) {
-  if(!missing(drop_uninformative_cols)) {
-    lifecycle::deprecate_warn("1.0.1.9010", "sbf_save_plot(drop_uninformative_cols)")
+#'
+sbf_save_plot <- function(
+  x = ggplot2::last_plot(),
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  caption = "",
+  report = TRUE,
+  tag = "",
+  notes = "",
+  units = "in",
+  width = NA,
+  height = width,
+  dpi = 300,
+  limitsize = TRUE,
+  csv = 1000L,
+  drop_uninformative_cols = TRUE
+) {
+  if (!missing(drop_uninformative_cols)) {
+    lifecycle::deprecate_warn(
+      "1.0.1.9010",
+      "sbf_save_plot(drop_uninformative_cols)"
+    )
   }
-  
+
   chk_s3_class(x, "ggplot")
   x_name <- chk_deparse(x_name)
   if (identical(x_name, "ggplot2::last_plot()")) {
@@ -702,14 +750,22 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
 
   dim <- plot_size(c(width, height), units = units)
 
-  ggplot2::ggsave(filename,
-    plot = x, width = dim[1], height = dim[2],
-    dpi = dpi, limitsize = limitsize
+  ggplot2::ggsave(
+    filename,
+    plot = x,
+    width = dim[1],
+    height = dim[2],
+    dpi = dpi,
+    limitsize = limitsize
   )
 
   meta <- list(
-    caption = caption, report = report, tag = tag, notes = notes,
-    width = dim[1], height = dim[2],
+    caption = caption,
+    report = report,
+    tag = tag,
+    notes = notes,
+    width = dim[1],
+    height = dim[2],
     dpi = dpi
   )
   save_meta(meta, "plots", sub = sub, main = main, x_name = x_name)
@@ -753,13 +809,19 @@ sbf_save_plot <- function(x = ggplot2::last_plot(), x_name = substitute(x),
 #' @inheritParams sbf_save_plot
 #' @family save functions
 #' @export
-sbf_save_window <- function(x_name = "window",
-                            sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            caption = "", report = TRUE, tag = "",
-                            notes = "",
-                            width = NA, height = width, units = "in",
-                            dpi = 300) {
+sbf_save_window <- function(
+  x_name = "window",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  caption = "",
+  report = TRUE,
+  tag = "",
+  notes = "",
+  width = NA,
+  height = width,
+  units = "in",
+  dpi = 300
+) {
   chk_string(x_name)
   chk_gt(nchar(x_name))
   chk_character(sub)
@@ -788,14 +850,22 @@ sbf_save_window <- function(x_name = "window",
   dim <- plot_size(c(width, height), units = units)
 
   grDevices::dev.print(
-    device = grDevices::png, filename = filename,
-    width = dim[1], height = dim[2],
-    units = "in", res = dpi
+    device = grDevices::png,
+    filename = filename,
+    width = dim[1],
+    height = dim[2],
+    units = "in",
+    res = dpi
   )
 
   meta <- list(
-    caption = caption, report = report, tag = tag, notes = notes,
-    width = dim[1], height = dim[2], dpi = dpi
+    caption = caption,
+    report = report,
+    tag = tag,
+    notes = notes,
+    width = dim[1],
+    height = dim[2],
+    dpi = dpi
   )
   save_meta(meta, "windows", sub = sub, main = main, x_name = x_name)
   invisible(filename)
@@ -828,13 +898,18 @@ sbf_basename_sans_ext <- function(x) {
 #' @inheritParams sbf_save_plot
 #' @family save functions
 #' @export
-sbf_save_png <- function(x, x_name = sbf_basename_sans_ext(x),
-                         sub = sbf_get_sub(),
-                         main = sbf_get_main(),
-                         caption = "", report = TRUE,
-                         tag = "",
-                         notes = "",
-                         width = NA, units = "in") {
+sbf_save_png <- function(
+  x,
+  x_name = sbf_basename_sans_ext(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  caption = "",
+  report = TRUE,
+  tag = "",
+  notes = "",
+  width = NA,
+  units = "in"
+) {
   chk_file(x)
   chk_ext(x, "png")
   chk_string(x_name)
@@ -863,8 +938,13 @@ sbf_save_png <- function(x, x_name = sbf_basename_sans_ext(x),
   file.copy(x, filename, overwrite = TRUE)
 
   meta <- list(
-    caption = caption, report = report, tag = tag, notes = notes,
-    width = dim[1], height = dim[2], dpi = dpi
+    caption = caption,
+    report = report,
+    tag = tag,
+    notes = notes,
+    width = dim[1],
+    height = dim[2],
+    dpi = dpi
   )
   save_meta(meta, "windows", sub = sub, main = main, x_name = x_name)
   invisible(filename)
@@ -892,12 +972,14 @@ sbf_save_png <- function(x, x_name = sbf_basename_sans_ext(x),
 #' sbf_save_excel()
 #' }
 #' @export
-sbf_save_excel <- function(x,
-                           x_name = substitute(x),
-                           max_sheets = 1L,
-                           sub = sbf_get_sub(),
-                           main = sbf_get_main(),
-                           epgs = NULL) {
+sbf_save_excel <- function(
+  x,
+  x_name = substitute(x),
+  max_sheets = 1L,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  epgs = NULL
+) {
   chk::chk_s3_class(x, "data.frame")
   x_name <- chk_deparse(x_name)
   chk::chk_string(x_name)
@@ -933,10 +1015,12 @@ sbf_save_excel <- function(x,
 #' sbf_save_gpkg()
 #' }
 #' @export
-sbf_save_gpkg <- function(x,
-                          x_name = substitute(x),
-                          sub = sbf_get_sub(),
-                          main = sbf_get_main()) {
+sbf_save_gpkg <- function(
+  x,
+  x_name = substitute(x),
+  sub = sbf_get_sub(),
+  main = sbf_get_main()
+) {
   chk::chk_s3_class(x, "data.frame")
   chk::chk_s3_class(x, "sf")
   x_name <- chk_deparse(x_name)
@@ -975,11 +1059,13 @@ sbf_save_gpkg <- function(x,
 #' sbf_save_workbook()
 #' }
 #' @export
-sbf_save_workbook <- function(workbook_name = basename(getwd()),
-                              sub = sbf_get_sub(),
-                              main = sbf_get_main(),
-                              env = parent.frame(),
-                              epgs = NULL) {
+sbf_save_workbook <- function(
+  workbook_name = basename(getwd()),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  env = parent.frame(),
+  epgs = NULL
+) {
   chk::chk_string(workbook_name)
   chk::chk_character(sub)
   chk::chk_range(length(sub))
@@ -1024,12 +1110,16 @@ sbf_save_workbook <- function(workbook_name = basename(getwd()),
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_data_to_db <- function(x, x_name = substitute(x),
-                                db_name = sbf_get_db_name(),
-                                sub = sbf_get_sub(),
-                                main = sbf_get_main(),
-                                commit = TRUE, strict = TRUE,
-                                silent = getOption("rws.silent", FALSE)) {
+sbf_save_data_to_db <- function(
+  x,
+  x_name = substitute(x),
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  commit = TRUE,
+  strict = TRUE,
+  silent = getOption("rws.silent", FALSE)
+) {
   chk_s3_class(x, "data.frame")
   x_name <- chk_deparse(x_name)
   chk_string(x_name)
@@ -1038,9 +1128,13 @@ sbf_save_data_to_db <- function(x, x_name = substitute(x),
   conn <- sbf_open_db(db_name, sub = sub, main = main, exists = TRUE)
   on.exit(sbf_close_db(conn))
 
-  rws_write(x,
-    x_name = x_name, exists = TRUE,
-    commit = commit, strict = strict, conn = conn,
+  rws_write(
+    x,
+    x_name = x_name,
+    exists = TRUE,
+    commit = commit,
+    strict = strict,
+    conn = conn,
     silent = silent
   )
   invisible(file_name(main, "dbs", sub, db_name, ext = "sqlite"))
@@ -1062,12 +1156,14 @@ sbf_save_data_to_db <- function(x, x_name = substitute(x),
 #' @return A invisible data.frame of the altered descriptions.
 #' @family save functions
 #' @export
-sbf_save_db_metatable_descriptions <- function(x,
-                                               db_name = sbf_get_db_name(),
-                                               sub = sbf_get_sub(),
-                                               main = sbf_get_main(),
-                                               overwrite = FALSE,
-                                               strict = TRUE) {
+sbf_save_db_metatable_descriptions <- function(
+  x,
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  overwrite = FALSE,
+  strict = TRUE
+) {
   check_data(x, values = list(Table = "", Column = "", Description = c("", NA)))
   chk_flag(overwrite)
   chk_flag(strict)
@@ -1105,8 +1201,11 @@ sbf_save_db_metatable_descriptions <- function(x,
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_objects <- function(sub = sbf_get_sub(),
-                             main = sbf_get_main(), env = parent.frame()) {
+sbf_save_objects <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  env = parent.frame()
+) {
   chk_s3_class(env, "environment")
 
   names <- objects(envir = env)
@@ -1130,8 +1229,11 @@ sbf_save_objects <- function(sub = sbf_get_sub(),
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_datas <- function(sub = sbf_get_sub(),
-                           main = sbf_get_main(), env = parent.frame()) {
+sbf_save_datas <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  env = parent.frame()
+) {
   chk_s3_class(env, "environment")
 
   names <- objects(envir = env)
@@ -1164,8 +1266,11 @@ sbf_save_datas <- function(sub = sbf_get_sub(),
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_spatials <- function(sub = sbf_get_sub(),
-                              main = sbf_get_main(), env = parent.frame()) {
+sbf_save_spatials <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  env = parent.frame()
+) {
   chk_s3_class(env, "environment")
 
   names <- objects(envir = env)
@@ -1196,10 +1301,12 @@ sbf_save_spatials <- function(sub = sbf_get_sub(),
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_numbers <- function(sub = sbf_get_sub(),
-                             main = sbf_get_main(), 
-                             signif = getOption("sbf.signif", 22),
-                             env = parent.frame()) {
+sbf_save_numbers <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  signif = getOption("sbf.signif", 22),
+  env = parent.frame()
+) {
   chk_s3_class(env, "environment")
 
   names <- objects(envir = env)
@@ -1208,7 +1315,9 @@ sbf_save_numbers <- function(sub = sbf_get_sub(),
     x_name <- names[i]
     x <- get(x = x_name, envir = env)
     is[i] <- is_number(x)
-    if (is[i]) sbf_save_number(x, x_name, sub = sub, main = main, signif = signif)
+    if (is[i]) {
+      sbf_save_number(x, x_name, sub = sub, main = main, signif = signif)
+    }
   }
   names <- names[is]
   if (!length(names)) {
@@ -1227,8 +1336,11 @@ sbf_save_numbers <- function(sub = sbf_get_sub(),
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_strings <- function(sub = sbf_get_sub(),
-                             main = sbf_get_main(), env = parent.frame()) {
+sbf_save_strings <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  env = parent.frame()
+) {
   chk_s3_class(env, "environment")
 
   names <- objects(envir = env)
@@ -1264,10 +1376,12 @@ sbf_save_strings <- function(sub = sbf_get_sub(),
 #' sbf_save_excels()
 #' }
 #' @export
-sbf_save_excels <- function(sub = sbf_get_sub(),
-                            main = sbf_get_main(),
-                            env = parent.frame(),
-                            epgs = NULL) {
+sbf_save_excels <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  env = parent.frame(),
+  epgs = NULL
+) {
   chk::chk_s3_class(env, "environment")
 
   names <- objects(envir = env)
@@ -1301,8 +1415,15 @@ save_gpkgs <- function(x, x_name, sub, main, all_sfcs) {
   sfc_column_names <- setdiff(sfc_column_names, active_sfc_column_name)
   for (sfc_column_name in sfc_column_names) {
     x <- sf::st_set_geometry(x, sfc_column_name)
-    x_name_column_name <- snakecase::to_snake_case(paste(x_name, sfc_column_name, "_"))
-    files <- c(sbf_save_gpkg(x, x_name = x_name_column_name, main = main, sub = sub), files)
+    x_name_column_name <- snakecase::to_snake_case(paste(
+      x_name,
+      sfc_column_name,
+      "_"
+    ))
+    files <- c(
+      sbf_save_gpkg(x, x_name = x_name_column_name, main = main, sub = sub),
+      files
+    )
   }
   files
 }
@@ -1321,9 +1442,12 @@ save_gpkgs <- function(x, x_name, sub, main, all_sfcs) {
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_gpkgs <- function(sub = sbf_get_sub(),
-                           main = sbf_get_main(), env = parent.frame(),
-                           all_sfcs = TRUE) {
+sbf_save_gpkgs <- function(
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  env = parent.frame(),
+  all_sfcs = TRUE
+) {
   chk_s3_class(env, "environment")
 
   files <- character(0)
@@ -1333,7 +1457,16 @@ sbf_save_gpkgs <- function(sub = sbf_get_sub(),
     x_name <- names[i]
     x <- get(x = x_name, envir = env)
     if (any_sfc(x)) {
-      files <- c(files, save_gpkgs(x, sub = sub, main = main, x_name = x_name, all_sfcs = all_sfcs))
+      files <- c(
+        files,
+        save_gpkgs(
+          x,
+          sub = sub,
+          main = main,
+          x_name = x_name,
+          all_sfcs = all_sfcs
+        )
+      )
     }
   }
   if (!length(files)) {
@@ -1355,21 +1488,26 @@ sbf_save_gpkgs <- function(sub = sbf_get_sub(),
 #' @return An invisible character vector of the paths to the saved objects.
 #' @family save functions
 #' @export
-sbf_save_datas_to_db <- function(db_name = sbf_get_db_name(),
-                                 sub = sbf_get_sub(),
-                                 main = sbf_get_main(),
-                                 commit = TRUE,
-                                 strict = TRUE,
-                                 env = parent.frame(),
-                                 silent = getOption("rws.silent", FALSE)) {
+sbf_save_datas_to_db <- function(
+  db_name = sbf_get_db_name(),
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  commit = TRUE,
+  strict = TRUE,
+  env = parent.frame(),
+  silent = getOption("rws.silent", FALSE)
+) {
   chk_s3_class(env, "environment")
 
   conn <- sbf_open_db(db_name, sub = sub, main = main, exists = TRUE)
   on.exit(sbf_close_db(conn))
 
-  rws_write(env,
+  rws_write(
+    env,
     exists = TRUE,
-    commit = commit, strict = strict, conn = conn,
+    commit = commit,
+    strict = strict,
+    conn = conn,
     silent = silent
   )
 }
@@ -1395,12 +1533,14 @@ sbf_save_datas_to_db <- function(db_name = sbf_get_db_name(),
 #' }
 #' @export
 
-sbf_save_db_to_workbook <- function(workbook_name = sbf_get_workbook_name(),
-                                    db_name = sbf_get_db_name(),
-                                    exclude_tables = "^$",
-                                    sub = sbf_get_sub(),
-                                    main = sbf_get_main(),
-                                    epgs = NULL) {
+sbf_save_db_to_workbook <- function(
+  workbook_name = sbf_get_workbook_name(),
+  db_name = sbf_get_db_name(),
+  exclude_tables = "^$",
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  epgs = NULL
+) {
   chk::chk_string(exclude_tables)
 
   conn <- sbf_open_db(db_name, sub = sub, main = main)
@@ -1462,21 +1602,23 @@ sbf_save_db_to_workbook <- function(workbook_name = sbf_get_workbook_name(),
 #' )
 #' }
 #' @export
-sbf_save_aws_files <- function(bucket_name,
-                               sub = sbf_get_sub(),
-                               main = sbf_get_main(),
-                               data_type = NULL,
-                               year = NULL,
-                               month = NULL,
-                               day = NULL,
-                               file_name = NULL,
-                               file_extension = NULL,
-                               max_request_size = 1000,
-                               ask = getOption("sbf.ask", TRUE),
-                               silent = TRUE,
-                               aws_access_key_id = Sys.getenv("AWS_ACCESS_KEY_ID"),
-                               aws_secret_access_key = Sys.getenv("AWS_SECRET_ACCESS_KEY"),
-                               region = Sys.getenv("AWS_REGION", "ca-central-1")) {
+sbf_save_aws_files <- function(
+  bucket_name,
+  sub = sbf_get_sub(),
+  main = sbf_get_main(),
+  data_type = NULL,
+  year = NULL,
+  month = NULL,
+  day = NULL,
+  file_name = NULL,
+  file_extension = NULL,
+  max_request_size = 1000,
+  ask = getOption("sbf.ask", TRUE),
+  silent = TRUE,
+  aws_access_key_id = Sys.getenv("AWS_ACCESS_KEY_ID"),
+  aws_secret_access_key = Sys.getenv("AWS_SECRET_ACCESS_KEY"),
+  region = Sys.getenv("AWS_REGION", "ca-central-1")
+) {
   lifecycle::deprecate_stop(
     "0.2.0",
     "sbf_save_aws_files()",

--- a/R/sub.R
+++ b/R/sub.R
@@ -32,7 +32,9 @@ sbf_set_sub <- function(..., rm = FALSE, ask = getOption("sbf.ask", TRUE)) {
   path <- file_path(..., collapse = TRUE)
   path <- sanitize_path(path)
   options(sbf.sub = path)
-  if (rm) rm_all(ask = ask)
+  if (rm) {
+    rm_all(ask = ask)
+  }
   invisible(path)
 }
 
@@ -93,7 +95,13 @@ sbf_up_sub <- function(n = 1L, rm = FALSE, ask = getOption("sbf.ask", TRUE)) {
   sub <- sbf_get_sub()
   nsub <- nsub(sub)
   if (n > nsub) {
-    abort_chk("`n` (", n, ") must not exceed the number of subfolders (", nsub, ")")
+    abort_chk(
+      "`n` (",
+      n,
+      ") must not exceed the number of subfolders (",
+      nsub,
+      ")"
+    )
   }
   sub <- strsplit(sub, "/")[[1]][-((nsub - n + 1L):nsub)]
   sbf_set_sub(sub, rm = rm, ask = ask)

--- a/R/write.R
+++ b/R/write.R
@@ -11,8 +11,12 @@
 #'
 #' @return An invisible character vector of the names of the data frames.
 #' @export
-sbf_write_datas_to_xlsx <- function(path, exists = NA, env = parent.frame(),
-                                    ask = getOption("sbf.ask", TRUE)) {
+sbf_write_datas_to_xlsx <- function(
+  path,
+  exists = NA,
+  env = parent.frame(),
+  ask = getOption("sbf.ask", TRUE)
+) {
   chk_string(path)
   chk_lgl(exists)
   chk_flag(ask)
@@ -20,7 +24,9 @@ sbf_write_datas_to_xlsx <- function(path, exists = NA, env = parent.frame(),
 
   rlang::check_installed("writexl")
 
-  if (isTRUE(exists)) chk_file(file)
+  if (isTRUE(exists)) {
+    chk_file(file)
+  }
 
   if (isFALSE(exists) && file.exists(file)) {
     if (ask && !yesno("Delete file '", file, "'?")) {

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/helper-pg.R
+++ b/tests/testthat/helper-pg.R
@@ -1,7 +1,9 @@
-create_local_database <- function(schema = NULL,
-                                  table = NULL,
-                                  data = TRUE,
-                                  env = parent.frame()) {
+create_local_database <- function(
+  schema = NULL,
+  table = NULL,
+  data = TRUE,
+  env = parent.frame()
+) {
   # create a local database, schema and table (with or without data)
   # all objects that are created are removed (complete clean up)
   chk::chk_null_or(schema, vld = chk::vld_string)
@@ -68,7 +70,11 @@ create_local_database <- function(schema = NULL,
     withr::defer(
       {
         sql_drop <- paste0(
-          "DROP TABLE ", schema, ".", deparse(substitute(table)), ";"
+          "DROP TABLE ",
+          schema,
+          ".",
+          deparse(substitute(table)),
+          ";"
         )
         result4 <- DBI::dbSendQuery(conn_local, sql_drop)
         DBI::dbClearResult(result4)
@@ -152,9 +158,11 @@ check_db_table <- function(config_path, schema, tbl_name) {
   query
 }
 
-clean_up_schema <- function(config_path,
-                            schema = "boat_count",
-                            env = parent.frame()) {
+clean_up_schema <- function(
+  config_path,
+  schema = "boat_count",
+  env = parent.frame()
+) {
   withr::defer(DBI::dbDisconnect(conn))
   conn <- local_connection(config_path)
   cmd <- paste0("DROP SCHEMA ", schema)

--- a/tests/testthat/test-archive.R
+++ b/tests/testthat/test-archive.R
@@ -24,7 +24,14 @@ test_that("archive message mac and linux", {
   sbf_save_number(x)
   expect_message(
     sbf_archive_main(ask = FALSE),
-    paste0("Directory '", sbf_get_main(), "' copied to '", sbf_get_main(), "-", dttr2::dtt_sys_date())
+    paste0(
+      "Directory '",
+      sbf_get_main(),
+      "' copied to '",
+      sbf_get_main(),
+      "-",
+      dttr2::dtt_sys_date()
+    )
   )
 })
 
@@ -76,12 +83,21 @@ test_that("unarchive", {
   expect_message(archive3 <- sbf_archive_main(ask = FALSE))
 
   expect_identical(sbf_load_number("x"), 3)
-  expect_message(expect_message(expect_equal(sbf_unarchive_main(archive = archive1, ask = FALSE), archive1)))
+  expect_message(expect_message(expect_equal(
+    sbf_unarchive_main(archive = archive1, ask = FALSE),
+    archive1
+  )))
   expect_identical(sbf_load_number("x"), 1)
-  expect_message(expect_message(expect_equal(as.character(sbf_unarchive_main(ask = FALSE)), archive3)))
+  expect_message(expect_message(expect_equal(
+    as.character(sbf_unarchive_main(ask = FALSE)),
+    archive3
+  )))
   expect_identical(sbf_load_number("x"), 3)
   expect_error(sbf_unarchive_main(archive = 2L, ask = FALSE))
-  expect_message(expect_message(expect_equal(as.character(sbf_unarchive_main(ask = FALSE)), archive2)))
+  expect_message(expect_message(expect_equal(
+    as.character(sbf_unarchive_main(ask = FALSE)),
+    archive2
+  )))
   expect_identical(sbf_load_number("x"), 2)
   expect_error(sbf_unarchive_main(ask = FALSE))
 })

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -72,7 +72,6 @@ test_that("compare_datas", {
   sbf_save_data(x)
   expect_message(archive2 <- sbf_archive_main(ask = FALSE))
 
-
   comparison <- sbf_compare_data_archive(
     main = archive1,
     archive = archive2,

--- a/tests/testthat/test-copy.R
+++ b/tests/testthat/test-copy.R
@@ -3,12 +3,15 @@ test_that("sbf_copy_db", {
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
 
-  expect_error(sbf_open_db(exists = TRUE),
+  expect_error(
+    sbf_open_db(exists = TRUE),
     "^`file` must specify an existing file [(]'.*dbs/database.sqlite' can't be found[)].$",
     class = "chk_error"
   )
 
-  path <- system.file("extdata", "example.sqlite",
+  path <- system.file(
+    "extdata",
+    "example.sqlite",
     package = "subfoldr2",
     mustWork = TRUE
   )
@@ -28,23 +31,28 @@ test_that("sbf_copy_db with different name", {
   sbf_reset_sub()
   withr::defer(sbf_reset_sub(ask = FALSE))
 
-  expect_error(sbf_open_db(exists = TRUE),
+  expect_error(
+    sbf_open_db(exists = TRUE),
     "^`file` must specify an existing file [(]'.*dbs/database.sqlite' can't be found[)].$",
     class = "chk_error"
   )
 
-  expect_error(sbf_open_db("new_one", exists = TRUE),
+  expect_error(
+    sbf_open_db("new_one", exists = TRUE),
     "^`file` must specify an existing file [(]'.*dbs/new_one.sqlite' can't be found[)].$",
     class = "chk_error"
   )
 
-  path <- system.file("extdata", "example.sqlite",
+  path <- system.file(
+    "extdata",
+    "example.sqlite",
     package = "subfoldr2",
     mustWork = TRUE
   )
   expect_true(sbf_copy_db(path, "new_one"))
 
-  expect_error(sbf_open_db(exists = TRUE),
+  expect_error(
+    sbf_open_db(exists = TRUE),
     "^`file` must specify an existing file [(]'.*dbs/database.sqlite' can't be found[)].$",
     class = "chk_error"
   )
@@ -60,18 +68,22 @@ test_that("sbf_copy_db error messages", {
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
 
-  path <- system.file("extdata", "example.png",
+  path <- system.file(
+    "extdata",
+    "example.png",
     package = "subfoldr2",
     mustWork = TRUE
   )
-  expect_error(sbf_copy_db(path),
+  expect_error(
+    sbf_copy_db(path),
     "^`path` must have extension 'db', 'sqlite' or 'sqlite3' [(]not 'png'[)][.]$",
     class = "chk_error"
   )
 
   path <- sub("[.]png$", ".db", path)
 
-  expect_error(sbf_open_db(path),
+  expect_error(
+    sbf_open_db(path),
     "^`file` must specify an existing file [(]'.*.example.db.sqlite' can't be found[)].$",
     class = "chk_error"
   )

--- a/tests/testthat/test-equal.R
+++ b/tests/testthat/test-equal.R
@@ -13,9 +13,7 @@ test_that("is_equal_data", {
   y <- x
   expect_false(sbf_is_equal_data(y))
   expect_identical(names(sbf_is_equal_data(y)), "data/y")
-  expect_equal(sbf_is_equal_data(y, exists = NA), NA,
-    ignore_attr = TRUE
-  )
+  expect_equal(sbf_is_equal_data(y, exists = NA), NA, ignore_attr = TRUE)
   expect_false(sbf_is_equal_data(y, exists = TRUE))
   expect_true(sbf_is_equal_data(y, exists = FALSE))
   expect_true(sbf_is_equal_data(y, "x"))
@@ -47,9 +45,7 @@ test_that("is_equal_datas", {
   )
   expect_identical(
     sbf_is_equal_data_archive("z"),
-    structure(logical(0),
-      .Names = character(0)
-    )
+    structure(logical(0), .Names = character(0))
   )
 
   expect_message(sbf_rm_main(ask = FALSE))
@@ -124,7 +120,11 @@ test_that("is_equal_datas", {
     c("data/x" = FALSE)
   )
   expect_identical(
-    sbf_is_equal_data_archive(main = archive1, archive = archive2, tolerance = 0.1),
+    sbf_is_equal_data_archive(
+      main = archive1,
+      archive = archive2,
+      tolerance = 0.1
+    ),
     c("data/x" = TRUE)
   )
 })

--- a/tests/testthat/test-execute-db.R
+++ b/tests/testthat/test-execute-db.R
@@ -5,8 +5,13 @@ test_that("create-db", {
 
   sbf_create_db()
 
-  expect_identical(sbf_execute_db("CREATE TABLE test (
-    x TEXT);"), 0L)
+  expect_identical(
+    sbf_execute_db(
+      "CREATE TABLE test (
+    x TEXT);"
+    ),
+    0L
+  )
 
   test <- tibble::tibble(x = "one")
   sbf_save_data_to_db(test)

--- a/tests/testthat/test-flob.R
+++ b/tests/testthat/test-flob.R
@@ -6,14 +6,18 @@ test_that("datas_to_db", {
   sbf_create_db()
 
   # 2 column pk
-  sbf_execute_db("CREATE TABLE df (
+  sbf_execute_db(
+    "CREATE TABLE df (
                 char TEXT NOT NULL,
                 num REAL NOT NULL,
-                PRIMARY KEY (char, num))")
+                PRIMARY KEY (char, num))"
+  )
 
   # one column pk with empty
-  sbf_execute_db("CREATE TABLE df2 (
-                char TEXT PRIMARY KEY NOT NULL)")
+  sbf_execute_db(
+    "CREATE TABLE df2 (
+                char TEXT PRIMARY KEY NOT NULL)"
+  )
 
   # one column pk with two blob cols
   df <- data.frame(char = c("a", "a", "b"), num = c(1, 2.1, 1))
@@ -24,13 +28,13 @@ test_that("datas_to_db", {
   flob <- flobr::flob_obj
   withr::defer(sbf_close_db(conn))
   conn <- sbf_open_db()
-  dbflobr::write_flob(flob,
+  dbflobr::write_flob(
+    flob,
     "New",
     "df",
     key = data.frame(char = "a", num = 1),
     conn
   )
-
 
   expect_message(
     expect_message(

--- a/tests/testthat/test-list.R
+++ b/tests/testthat/test-list.R
@@ -165,19 +165,22 @@ test_that("list tables", {
   sbf_save_table(x)
   sbf_save_table(x, sub = "down")
 
-
   expect_match(sbf_list_tables(), "tables/x.rds$")
   expect_match(names(sbf_list_tables()), "tables/x")
 
   expect_equal(
-    ignore_attr = TRUE, sbf_list_tables(recursive = TRUE),
+    ignore_attr = TRUE,
+    sbf_list_tables(recursive = TRUE),
     c(
       file.path(sbf_get_main(), "tables/down/x.rds"),
       file.path(sbf_get_main(), "tables/x.rds")
     )
   )
 
-  expect_equal(names(sbf_list_tables(recursive = TRUE)), c("tables/down/x", "tables/x"))
+  expect_equal(
+    names(sbf_list_tables(recursive = TRUE)),
+    c("tables/down/x", "tables/x")
+  )
 })
 
 
@@ -193,14 +196,18 @@ test_that("list numbers", {
   expect_match(names(sbf_list_numbers()), "numbers/1")
 
   expect_equal(
-    ignore_attr = TRUE, sbf_list_numbers(recursive = TRUE),
+    ignore_attr = TRUE,
+    sbf_list_numbers(recursive = TRUE),
     c(
       file.path(sbf_get_main(), "numbers/1.rds"),
       file.path(sbf_get_main(), "numbers/down/1.rds")
     )
   )
 
-  expect_equal(names(sbf_list_numbers(recursive = TRUE)), c("numbers/1", "numbers/down/1"))
+  expect_equal(
+    names(sbf_list_numbers(recursive = TRUE)),
+    c("numbers/1", "numbers/down/1")
+  )
 })
 
 test_that("list strings", {
@@ -215,14 +222,18 @@ test_that("list strings", {
   expect_match(names(sbf_list_strings()), "strings/x")
 
   expect_equal(
-    ignore_attr = TRUE, sbf_list_strings(recursive = TRUE),
+    ignore_attr = TRUE,
+    sbf_list_strings(recursive = TRUE),
     c(
       file.path(sbf_get_main(), "strings/down/x.rds"),
       file.path(sbf_get_main(), "strings/x.rds")
     )
   )
 
-  expect_equal(names(sbf_list_strings(recursive = TRUE)), c("strings/down/x", "strings/x"))
+  expect_equal(
+    names(sbf_list_strings(recursive = TRUE)),
+    c("strings/down/x", "strings/x")
+  )
 })
 
 test_that("list blocks", {
@@ -237,14 +248,18 @@ test_that("list blocks", {
   expect_match(names(sbf_list_blocks()), "blocks/x")
 
   expect_equal(
-    ignore_attr = TRUE, sbf_list_blocks(recursive = TRUE),
+    ignore_attr = TRUE,
+    sbf_list_blocks(recursive = TRUE),
     c(
       file.path(sbf_get_main(), "blocks/down/x.rds"),
       file.path(sbf_get_main(), "blocks/x.rds")
     )
   )
 
-  expect_equal(names(sbf_list_blocks(recursive = TRUE)), c("blocks/down/x", "blocks/x"))
+  expect_equal(
+    names(sbf_list_blocks(recursive = TRUE)),
+    c("blocks/down/x", "blocks/x")
+  )
 })
 
 test_that("list plots", {
@@ -262,14 +277,18 @@ test_that("list plots", {
   expect_match(names(sbf_list_plots()), "plots/x")
 
   expect_equal(
-    ignore_attr = TRUE, sbf_list_plots(recursive = TRUE),
+    ignore_attr = TRUE,
+    sbf_list_plots(recursive = TRUE),
     c(
       file.path(sbf_get_main(), "plots/down/x.rds"),
       file.path(sbf_get_main(), "plots/x.rds")
     )
   )
 
-  expect_equal(names(sbf_list_plots(recursive = TRUE)), c("plots/down/x", "plots/x"))
+  expect_equal(
+    names(sbf_list_plots(recursive = TRUE)),
+    c("plots/down/x", "plots/x")
+  )
 })
 
 test_that("list windows", {
@@ -277,7 +296,9 @@ test_that("list windows", {
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
 
-  png <- system.file("extdata", "example.png",
+  png <- system.file(
+    "extdata",
+    "example.png",
     package = "subfoldr2",
     mustWork = TRUE
   )
@@ -288,14 +309,18 @@ test_that("list windows", {
   expect_match(names(sbf_list_windows()), "windows/example")
 
   expect_equal(
-    ignore_attr = TRUE, sbf_list_windows(recursive = TRUE),
+    ignore_attr = TRUE,
+    sbf_list_windows(recursive = TRUE),
     c(
       file.path(sbf_get_main(), "windows/down/example.png"),
       file.path(sbf_get_main(), "windows/example.png")
     )
   )
 
-  expect_equal(names(sbf_list_windows(recursive = TRUE)), c("windows/down/example", "windows/example"))
+  expect_equal(
+    names(sbf_list_windows(recursive = TRUE)),
+    c("windows/down/example", "windows/example")
+  )
 })
 
 test_that("list dbs", {
@@ -306,17 +331,20 @@ test_that("list dbs", {
   sbf_open_db(exists = FALSE)
   sbf_open_db(exists = FALSE, sub = "down")
 
-
   expect_match(sbf_list_dbs(), "dbs/database.sqlite$")
   expect_match(names(sbf_list_dbs()), "dbs/database")
 
   expect_equal(
-    ignore_attr = TRUE, sbf_list_dbs(recursive = TRUE),
+    ignore_attr = TRUE,
+    sbf_list_dbs(recursive = TRUE),
     c(
       file.path(sbf_get_main(), "dbs/database.sqlite"),
       file.path(sbf_get_main(), "dbs/down/database.sqlite")
     )
   )
 
-  expect_equal(names(sbf_list_dbs(recursive = TRUE)), c("dbs/database", "dbs/down/database"))
+  expect_equal(
+    names(sbf_list_dbs(recursive = TRUE)),
+    c("dbs/database", "dbs/down/database")
+  )
 })

--- a/tests/testthat/test-open-close.R
+++ b/tests/testthat/test-open-close.R
@@ -42,7 +42,8 @@ test_that("db", {
 
   withr::defer(graphics.off())
 
-  expect_error(sbf_open_db("x"),
+  expect_error(
+    sbf_open_db("x"),
     "^`file` must specify an existing file [(]'.*dbs/x.sqlite' can't be found[)].$",
     class = "chk_error"
   )

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -91,12 +91,17 @@ test_that("path windows", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
 
-  png <- system.file("extdata", "example.png",
+  png <- system.file(
+    "extdata",
+    "example.png",
     package = "subfoldr2",
     mustWork = TRUE
   )
   sbf_save_png(png)
 
-  expect_match(sbf_path_window("example", exists = TRUE), ".*/windows/example[.]png")
+  expect_match(
+    sbf_path_window("example", exists = TRUE),
+    ".*/windows/example[.]png"
+  )
   chk::expect_chk_error(sbf_path_window("example", exists = FALSE))
 })

--- a/tests/testthat/test-query-db.R
+++ b/tests/testthat/test-query-db.R
@@ -6,8 +6,13 @@ test_that("query-db", {
   sbf_create_db()
   test <- tibble::tibble(x = "one")
 
-  expect_identical(sbf_execute_db("CREATE TABLE test (
-    x TEXT);"), 0L)
+  expect_identical(
+    sbf_execute_db(
+      "CREATE TABLE test (
+    x TEXT);"
+    ),
+    0L
+  )
 
   sbf_save_data_to_db(test)
 

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2,17 +2,18 @@ test_that("object", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   x <- 1
   expect_warning(sbf_load_objects(), "no objects to load")
-  
+
   expect_error(
     sbf_save_object(x_name = "x"),
     "argument \"x\" is missing, with no default"
   )
-  expect_error(sbf_save_object(),
-               "^`nchar[(]x_name[)]` must be greater than 0, not 0[.]$",
-               class = "chk_error"
+  expect_error(
+    sbf_save_object(),
+    "^`nchar[(]x_name[)]` must be greater than 0, not 0[.]$",
+    class = "chk_error"
   )
   expect_identical(
     sbf_save_object(x),
@@ -24,7 +25,7 @@ test_that("object", {
   chk::expect_chk_error(sbf_load_object("x2"))
   expect_null(sbf_load_object("x2", exists = FALSE))
   expect_null(sbf_load_object("x2", exists = NA))
-  
+
   y <- 2
   expect_identical(
     sbf_save_objects(env = as.environment(list(x = x, y = y))),
@@ -38,22 +39,22 @@ test_that("object", {
   expect_identical(sbf_load_objects(), c("x", "y"))
   expect_identical(x, 1)
   expect_identical(y, 2)
-  
+
   expect_identical(sbf_reset_sub(), character(0))
   expect_identical(sbf_load_object("x"), x)
-  
+
   expect_identical(
     list.files(file.path(sbf_get_main(), "objects")),
     sort(c("x.rds", "y.rds"))
   )
-  
+
   data <- sbf_load_objects_recursive(".rds", sub = character(0))
-  
+
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("objects", "name", "sub", "file"))
   expect_identical(nrow(data), 0L)
   expect_type(data$objects, "list")
-  
+
   data <- sbf_load_objects_recursive(
     include_root = FALSE,
     sub = character(0)
@@ -61,7 +62,7 @@ test_that("object", {
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("objects", "name", "sub", "file"))
   expect_identical(nrow(data), 0L)
-  
+
   data <- sbf_load_objects_recursive(sub = character(0))
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("objects", "name", "sub", "file"))
@@ -75,12 +76,12 @@ test_that("object", {
       file.path(sbf_get_main(), "objects/y.rds")
     )
   )
-  
+
   expect_identical(
     sbf_save_object(x, sub = "t2/t3"),
     file.path(sbf_get_main(), "objects/t2/t3/x.rds")
   )
-  
+
   data <- sbf_load_objects_recursive(sub = character(0))
   expect_s3_class(data, "tbl_df")
   expect_identical(
@@ -101,7 +102,7 @@ test_that("object", {
       file.path(sbf_get_main(), "objects/y.rds")
     )
   )
-  
+
   data <- sbf_load_objects_recursive(sub = character(0), include_root = FALSE)
   expect_s3_class(data, "tbl_df")
   expect_identical(
@@ -117,13 +118,14 @@ test_that("object", {
     data$file,
     file.path(sbf_get_main(), "objects/t2/t3/x.rds")
   )
-  
-  data2 <- sbf_load_objects_recursive("^x",
-                                      sub = character(0),
-                                      include_root = FALSE
+
+  data2 <- sbf_load_objects_recursive(
+    "^x",
+    sub = character(0),
+    include_root = FALSE
   )
   expect_identical(data2, data)
-  
+
   data <- sbf_load_objects_recursive(sub = "t2")
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("objects", "name", "sub", "file"))
@@ -134,8 +136,11 @@ test_that("object", {
     data$file,
     file.path(sbf_get_main(), "objects/t2/t3/x.rds")
   )
-  
-  expect_message(expect_identical(sbf_reset_sub(rm = TRUE, ask = FALSE), character(0)))
+
+  expect_message(expect_identical(
+    sbf_reset_sub(rm = TRUE, ask = FALSE),
+    character(0)
+  ))
   chk::expect_chk_error(sbf_load_object("x"))
   expect_identical(sbf_set_sub("sub"), "sub")
   expect_identical(
@@ -154,11 +159,11 @@ test_that("object", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   x <- 1
   sbf_set_sub("one")
   sbf_save_object(x)
-  
+
   data <- sbf_load_objects_recursive(sub = character(0))
   expect_s3_class(data, "tbl_df")
   expect_identical(
@@ -166,10 +171,10 @@ test_that("object", {
     c("objects", "name", "sub", "file")
   )
   expect_identical(data$sub, c("one"))
-  
+
   sbf_set_sub("one", "two")
   sbf_save_object(x)
-  
+
   data <- sbf_load_objects_recursive(sub = character(0))
   expect_s3_class(data, "tbl_df")
   expect_identical(
@@ -177,7 +182,7 @@ test_that("object", {
     c("objects", "name", "sub", "sub1", "sub2", "file")
   )
   expect_identical(data$sub, c("one/two", "one"))
-  
+
   expect_identical(
     sbf_subs_object_recursive("x", sub = character(0)),
     c("one/two", "one")
@@ -192,106 +197,130 @@ test_that("spatial", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   # test empty batch load while folder empty
   expect_warning(sbf_load_spatials(), "no spatial to load")
-  
+
   # test spatial checks
   y <- 1
   expect_error(check_spatial(), "argument \"x\" is missing, with no default")
   expect_error(check_spatial(y), "^`y` must inherit from S3 class 'sf'[.]$")
   expect_false(valid_spatial(y))
-  
+
   y <- sf::st_point(c(0, 1)) |>
     sf::st_sfc() |>
     sf::st_as_sf()
   y <- y[0, ]
-  expect_error(check_spatial(y), "^`nrow\\(y\\)` must be between 1 and Inf, not 0[.]$")
+  expect_error(
+    check_spatial(y),
+    "^`nrow\\(y\\)` must be between 1 and Inf, not 0[.]$"
+  )
   expect_false(valid_spatial(y))
-  
+
   y <- sf::st_point(c(0, 1)) |>
     sf::st_sfc() |>
     sf::st_as_sf()
-  expect_error(check_spatial(y), "^`ncol\\(y\\)` must be between 2 and Inf, not 1[.]$")
+  expect_error(
+    check_spatial(y),
+    "^`ncol\\(y\\)` must be between 2 and Inf, not 1[.]$"
+  )
   expect_false(valid_spatial(y))
-  
+
   y <- data.frame(index = c(1, 2))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y)
   expect_error(check_spatial(y), "^`y` must not have a missing projection[.]$")
   expect_false(valid_spatial(y))
-  
+
   y <- data.frame(index = c(1, 2))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y$geometry2 <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
-  expect_error(check_spatial(y), "^`y` must have exactly one geometry column[.]$")
+  expect_error(
+    check_spatial(y),
+    "^`y` must have exactly one geometry column[.]$"
+  )
   expect_false(valid_spatial(y))
-  
+
   y <- data.frame(index = c(1, 2))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
   y <- y[, 2:1]
-  expect_error(check_spatial(y), "^`y` must not have a first \\(index\\) column that is also the geometry column[.]$")
+  expect_error(
+    check_spatial(y),
+    "^`y` must not have a first \\(index\\) column that is also the geometry column[.]$"
+  )
   expect_false(valid_spatial(y))
-  
+
   y <- data.frame(index = c(1, NA))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
-  expect_error(check_spatial(y), "^`y` must not have a first \\(index\\) column with missing values[.]$")
+  expect_error(
+    check_spatial(y),
+    "^`y` must not have a first \\(index\\) column with missing values[.]$"
+  )
   expect_false(valid_spatial(y))
-  
+
   y <- data.frame(index = c(1, 1))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
-  expect_error(check_spatial(y), "^`y` must not have a first \\(index\\) column with duplicated values[.]$")
+  expect_error(
+    check_spatial(y),
+    "^`y` must not have a first \\(index\\) column with duplicated values[.]$"
+  )
   expect_false(valid_spatial(y))
   # test that spatial check remains within context of higher function
-  expect_error(sbf_save_spatial(y), "^`y` must not have a first \\(index\\) column with duplicated values[.]$")
-  
+  expect_error(
+    sbf_save_spatial(y),
+    "^`y` must not have a first \\(index\\) column with duplicated values[.]$"
+  )
+
   # test case where checks pass
   y <- data.frame(index = c(1, 2))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
   expect_identical(check_spatial(y), y)
   expect_true(valid_spatial(y))
-  
+
   # test save/load spatial
   expect_error(sbf_save_spatial(), "argument \"x\" is missing, with no default")
-  
+
   y <- data.frame(index = c(1, 2))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
   sbf_save_spatial(y)
-  expect_identical(sbf_save_spatial(y), file.path(sbf_get_main(), "spatial/y.rds"))
+  expect_identical(
+    sbf_save_spatial(y),
+    file.path(sbf_get_main(), "spatial/y.rds")
+  )
   expect_identical(sbf_load_spatial("y"), y)
   chk::expect_chk_error(sbf_load_spatial("y2"))
   expect_true(file.exists(file.path(sbf_get_main(), "spatial", "y.rds")))
   expect_false(file.exists(file.path(sbf_get_main(), "spatial", "y2.rds")))
   suppressMessages(sbf_rm_main(ask = FALSE))
-  
+
   # overwrite good obj with bad, then check load in warnings
   y <- data.frame(index = c(1, 2))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
   sbf_save_spatial(y)
-  
+
   y <- data.frame(x = 1)
   saveRDS(y, file = file.path(sbf_get_main(), "spatial", "y.rds"))
   saveRDS(y, file = file.path(sbf_get_main(), "spatial", "x.rds"))
   expect_warning(sbf_load_spatial("y"), "^`y`is not a valid spatial object[.]$")
-  
+
   warnings <- capture_warnings(sbf_load_spatials())
   expect_identical(warnings[1], "`x`is not a valid spatial object.")
   expect_identical(warnings[2], "`y`is not a valid spatial object.")
   suppressMessages(sbf_rm_main(ask = FALSE))
-  
+
   # test pluralised spatial funs
   y <- data.frame(index = c(1, 2))
   y$geometry <- sf::st_point(c(0, 1)) |> sf::st_sfc()
   y <- sf::st_as_sf(y, crs = 3264)
   z <- y
-  
+
   expect_identical(
     sbf_save_spatials(env = as.environment(list(y = y, z = z))),
     c(
@@ -299,12 +328,12 @@ test_that("spatial", {
       file.path(sbf_get_main(), "spatial/z.rds")
     )
   )
-  
+
   expect_identical(
     list.files(file.path(sbf_get_main(), "spatial")),
     sort(c("y.rds", "z.rds"))
   )
-  
+
   y <- 0
   z <- 0
   expect_identical(sbf_load_spatials(), c("y", "z"))
@@ -321,23 +350,24 @@ test_that("data", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   y <- 1
   expect_warning(sbf_load_datas(), "no data to load")
-  
+
   expect_error(sbf_save_data(), "argument \"x\" is missing, with no default")
-  expect_error(sbf_save_data(y),
-               "^`x` must inherit from S3 class 'data.frame'[.]$",
-               class = "chk_error"
+  expect_error(
+    sbf_save_data(y),
+    "^`x` must inherit from S3 class 'data.frame'[.]$",
+    class = "chk_error"
   )
   x <- data.frame(x = 1)
   expect_identical(sbf_save_data(x), file.path(sbf_get_main(), "data/x.rds"))
   expect_identical(sbf_load_data("x"), x)
   chk::expect_chk_error(sbf_load_data("x2"))
-  
+
   expect_true(file.exists(file.path(sbf_get_main(), "data", "x.rds")))
   expect_false(file.exists(file.path(sbf_get_main(), "data", "x2.rds")))
-  
+
   y <- data.frame(z = 3)
   expect_identical(
     sbf_save_datas(env = as.environment(list(x = x, y = y))),
@@ -355,7 +385,7 @@ test_that("data", {
   expect_identical(sbf_load_datas(), c("x", "y"))
   expect_identical(x, data.frame(x = 1))
   expect_identical(y, data.frame(z = 3))
-  
+
   data <- sbf_load_datas_recursive()
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("data", "name", "sub", "file"))
@@ -368,10 +398,13 @@ test_that("data", {
       file.path(sbf_get_main(), "data/y.rds")
     )
   )
-  
+
   expect_identical(sbf_reset_sub(), character(0))
   expect_identical(sbf_load_data("x"), x)
-  expect_message(expect_identical(sbf_reset_sub(rm = TRUE, ask = FALSE), character(0)))
+  expect_message(expect_identical(
+    sbf_reset_sub(rm = TRUE, ask = FALSE),
+    character(0)
+  ))
   chk::expect_chk_error(sbf_load_data("x"))
   expect_identical(sbf_set_sub("sub"), "sub")
   expect_identical(
@@ -390,26 +423,27 @@ test_that("number", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   y <- numeric(0)
   expect_warning(sbf_load_numbers(), "no numbers to load")
   expect_error(
     sbf_save_number(),
     "argument \"x\" is missing, with no default"
   )
-  expect_error(sbf_save_number(y),
-               "^`x` must be a number [(]non-missing numeric scalar[)][.]$",
-               class = "chk_error"
+  expect_error(
+    sbf_save_number(y),
+    "^`x` must be a number [(]non-missing numeric scalar[)][.]$",
+    class = "chk_error"
   )
   x <- 1L
   expect_identical(
     sbf_save_number(x),
     file.path(sbf_get_main(), "numbers/x.rds")
   )
-  
+
   expect_true(file.exists(file.path(sbf_get_main(), "numbers", "x.rds")))
   expect_false(file.exists(file.path(sbf_get_main(), "numbers", "x2.rds")))
-  
+
   expect_identical(sbf_load_number("x"), 1)
   expect_identical(
     list.files(file.path(sbf_get_main(), "numbers")),
@@ -417,7 +451,7 @@ test_that("number", {
   )
   csv <- read.csv(file.path(sbf_get_main(), "numbers", "x.csv"))
   expect_equal(csv, data.frame(x = 1))
-  
+
   y <- 3
   expect_identical(
     sbf_save_numbers(env = as.environment(list(x = x, y = y))),
@@ -435,7 +469,7 @@ test_that("number", {
   expect_identical(sbf_load_numbers(), c("x", "y"))
   expect_identical(x, 1)
   expect_identical(y, 3)
-  
+
   data <- sbf_load_numbers_recursive()
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("numbers", "name", "sub", "file"))
@@ -448,11 +482,14 @@ test_that("number", {
       file.path(sbf_get_main(), "numbers/y.rds")
     )
   )
-  
+
   chk::expect_chk_error(sbf_load_number("x2"))
   expect_identical(sbf_reset_sub(), character(0))
   expect_identical(sbf_load_number("x"), 1)
-  expect_message(expect_identical(sbf_reset_sub(rm = TRUE, ask = FALSE), character(0)))
+  expect_message(expect_identical(
+    sbf_reset_sub(rm = TRUE, ask = FALSE),
+    character(0)
+  ))
   chk::expect_chk_error(sbf_load_number("x"))
   expect_identical(sbf_set_sub("sub"), "sub")
   expect_identical(
@@ -464,24 +501,27 @@ test_that("number", {
   chk::expect_chk_error(sbf_load_number("x2", exists = TRUE))
   expect_null(sbf_load_number("x2", exists = NA))
   expect_null(sbf_load_number("x2", exists = FALSE))
-  
+
   z <- 4L
   expect_identical(
     sbf_save_number(z, x_name = "important_num"),
     file.path(sbf_get_main(), "numbers/sub/important_num.rds")
   )
-  expect_true(file.exists(file.path(sbf_get_main(), "numbers/sub/important_num.rds")))
+  expect_true(file.exists(file.path(
+    sbf_get_main(),
+    "numbers/sub/important_num.rds"
+  )))
   expect_false(file.exists(file.path(sbf_get_main(), "numbers/sub/z.rds")))
   expect_identical(sbf_load_number("important_num"), 4)
   csv <- read.csv(file.path(sbf_get_main(), "numbers/sub/important_num.csv"))
   expect_equal(csv, data.frame(x = 4))
-  
+
   sbf_save_number(66666.6666, x_name = "sixes")
   expect_identical(sbf_load_number("sixes"), 66666.6666)
-  
+
   sbf_save_number(66666.6666, x_name = "sixes", signif = 4)
   expect_identical(sbf_load_number("sixes"), 66670)
-  
+
   withr::local_options(list(sbf.signif = 5))
   sbf_save_number(66666.6666, x_name = "sixes")
   expect_identical(sbf_load_number("sixes"), 66667)
@@ -491,7 +531,7 @@ test_that("string", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   y <- "two words"
   expect_warning(sbf_load_strings(), "no strings to load")
   expect_error(
@@ -502,10 +542,10 @@ test_that("string", {
     sbf_save_string(y),
     file.path(sbf_get_main(), "strings/y.rds")
   )
-  
+
   expect_true(file.exists(file.path(sbf_get_main(), "strings", "y.rds")))
   expect_false(file.exists(file.path(sbf_get_main(), "strings", "x2.rds")))
-  
+
   expect_identical(sbf_load_string("y"), "two words")
   expect_identical(
     list.files(file.path(sbf_get_main(), "strings")),
@@ -513,7 +553,7 @@ test_that("string", {
   )
   txt <- readLines(file.path(sbf_get_main(), "strings", "y.txt"), warn = FALSE)
   expect_equal(txt, "two words")
-  
+
   x <- "one"
   expect_identical(
     sbf_save_strings(env = as.environment(list(x = x, y = y))),
@@ -531,7 +571,7 @@ test_that("string", {
   expect_identical(sbf_load_strings(), c("x", "y"))
   expect_identical(x, "one")
   expect_identical(y, "two words")
-  
+
   data <- sbf_load_strings_recursive()
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("strings", "name", "sub", "file"))
@@ -544,11 +584,14 @@ test_that("string", {
       file.path(sbf_get_main(), "strings/y.rds")
     )
   )
-  
+
   chk::expect_chk_error(sbf_load_string("x2"))
   expect_identical(sbf_reset_sub(), character(0))
   expect_identical(sbf_load_string("y"), "two words")
-  expect_message(expect_identical(sbf_reset_sub(rm = TRUE, ask = FALSE), character(0)))
+  expect_message(expect_identical(
+    sbf_reset_sub(rm = TRUE, ask = FALSE),
+    character(0)
+  ))
   chk::expect_chk_error(sbf_load_string("x"))
   expect_identical(sbf_set_sub("sub"), "sub")
   expect_identical(
@@ -561,7 +604,7 @@ test_that("string", {
   chk::expect_chk_error(sbf_load_string("x2"))
   expect_null(sbf_load_string("x2", exists = NA))
   expect_null(sbf_load_string("x2", exists = FALSE))
-  
+
   data <- sbf_load_strings_recursive()
   expect_identical(colnames(data), c("strings", "name", "sub", "file"))
   expect_identical(data$strings, "two words")
@@ -573,49 +616,56 @@ test_that("datas_to_db", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   x <- data.frame(x = 1)
   y <- data.frame(z = 3)
-  expect_error(sbf_save_datas_to_db(env = as.environment(list(x = x, y = y))),
-               "^`file` must specify an existing file [(]'.*dbs/database.sqlite' can't be found[)].$",
-               class = "chk_error"
+  expect_error(
+    sbf_save_datas_to_db(env = as.environment(list(x = x, y = y))),
+    "^`file` must specify an existing file [(]'.*dbs/database.sqlite' can't be found[)].$",
+    class = "chk_error"
   )
-  
+
   conn <- sbf_open_db(exists = NA)
   withr::defer(suppressWarnings(DBI::dbDisconnect(conn)))
   expect_identical(
     list.files(file.path(sbf_get_main(), "dbs")),
     "database.sqlite"
   )
-  
+
   expect_error(
     sbf_save_datas_to_db(env = as.environment(list(x = x, y = y))),
     "The following data frames in 'x' are unrecognised: 'y' and 'x'; but exists = TRUE."
   )
-  
-  DBI::dbExecute(conn, "CREATE TABLE x (
-                  x INTEGER PRIMARY KEY NOT NULL)")
-  
-  sbf_execute_db("CREATE TABLE y (
-                  z INTEGER PRIMARY KEY NOT NULL)")
-  
+
+  DBI::dbExecute(
+    conn,
+    "CREATE TABLE x (
+                  x INTEGER PRIMARY KEY NOT NULL)"
+  )
+
+  sbf_execute_db(
+    "CREATE TABLE y (
+                  z INTEGER PRIMARY KEY NOT NULL)"
+  )
+
   expect_identical(
     sbf_save_datas_to_db(env = as.environment(list(x = x, y = y))),
     c("y", "x")
   )
-  
+
   expect_error(
     sbf_save_datas_to_db(env = as.environment(list(x = x, y = y))),
     "UNIQUE constraint failed: y.z"
   )
-  
+
   expect_true(sbf_close_db(conn))
   x <- 0
   y <- 0
-  
-  expect_error(sbf_load_datas_from_db("z"),
-               "^`file` must specify an existing file [(]'.*dbs/z.sqlite' can't be found[)].$",
-               class = "chk_error"
+
+  expect_error(
+    sbf_load_datas_from_db("z"),
+    "^`file` must specify an existing file [(]'.*dbs/z.sqlite' can't be found[)].$",
+    class = "chk_error"
   )
   expect_identical(sbf_load_datas_from_db(), c("x", "y"))
   expect_identical(x, tibble::tibble(x = 1L))
@@ -626,7 +676,7 @@ test_that("datas_to_db", {
   )
   expect_identical(dbx, tibble::tibble(x = 1L))
   expect_identical(dby, tibble::tibble(z = 3L))
-  
+
   expect_error(
     sbf_save_data_to_db(x, db_name = "database"),
     "UNIQUE constraint failed: x.x"
@@ -635,7 +685,7 @@ test_that("datas_to_db", {
   file <- sbf_save_data_to_db(x, db_name = "database")
   expect_match(file, ".+/dbs/database.sqlite")
   expect_identical(sbf_load_data_from_db("x"), tibble::tibble(x = c(1L, 4L)))
-  
+
   expect_identical(
     sbf_load_db_metatable(),
     tibble::tibble(
@@ -645,7 +695,7 @@ test_that("datas_to_db", {
       Description = c(NA_character_, NA_character_)
     )
   )
-  
+
   x <- sbf_load_db_metatable()
   x$Description <- c("xy", "the End.")
   expect_identical(
@@ -681,27 +731,31 @@ test_that("datas_to_db", {
     sbf_save_db_metatable_descriptions(x, overwrite = TRUE),
     x[c("Table", "Column", "Description")]
   )
-  
+
   x$Table[1] <- "NotTable"
   expect_error(sbf_save_db_metatable_descriptions(x))
   expect_identical(
     sbf_save_db_metatable_descriptions(x, strict = FALSE),
     x[0, c("Table", "Column", "Description")]
   )
-  expect_identical(sbf_save_db_metatable_descriptions(
-    x,
-    strict = FALSE, overwrite = TRUE
-  )$Description, "yes")
-  
+  expect_identical(
+    sbf_save_db_metatable_descriptions(
+      x,
+      strict = FALSE,
+      overwrite = TRUE
+    )$Description,
+    "yes"
+  )
+
   x$Table[1] <- "X"
   x$Description <- NA_character_
   expect_identical(
     sbf_save_db_metatable_descriptions(x, overwrite = TRUE),
     x[c("Table", "Column", "Description")]
   )
-  
+
   expect_identical(sbf_load_db_metatable(), x)
-  
+
   expect_identical(
     sbf_save_db_metatable_descriptions(x),
     x[c("Table", "Column", "Description")]
@@ -712,28 +766,30 @@ test_that("table", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   y <- 1
   expect_warning(sbf_load_tables(), "no tables to load")
   expect_error(
     sbf_save_table(),
     "argument \"x\" is missing, with no default"
   )
-  expect_error(sbf_save_table(y),
-               "^`x` must inherit from S3 class 'data.frame'[.]$",
-               class = "chk_error"
+  expect_error(
+    sbf_save_table(y),
+    "^`x` must inherit from S3 class 'data.frame'[.]$",
+    class = "chk_error"
   )
   x <- data.frame(x = 1)
-  expect_error(sbf_save_table(data.frame(zz = I(list(t = 3))), x_name = "y"),
-               "^The following columns in `x` are not logical, numeric, character, factor, Date, hms or POSIXct: 'zz'[.]$",
-               class = "chk_error"
+  expect_error(
+    sbf_save_table(data.frame(zz = I(list(t = 3))), x_name = "y"),
+    "^The following columns in `x` are not logical, numeric, character, factor, Date, hms or POSIXct: 'zz'[.]$",
+    class = "chk_error"
   )
-  
+
   expect_identical(sbf_save_table(x), file.path(sbf_get_main(), "tables/x.rds"))
-  
+
   expect_true(file.exists(file.path(sbf_get_main(), "tables/x.rds")))
   expect_false(file.exists(file.path(sbf_get_main(), "tables/x2.rds")))
-  
+
   expect_identical(sbf_load_table("x"), x)
   expect_identical(
     list.files(file.path(sbf_get_main(), "tables")),
@@ -742,8 +798,11 @@ test_that("table", {
   csv <- read.csv(file.path(sbf_get_main(), "tables", "x.csv"))
   expect_equal(csv, x)
   meta <- yaml::read_yaml(file.path(sbf_get_main(), "tables", "x.yaml"))
-  expect_identical(meta, list(caption = "", report = TRUE, tag = "", notes = ""))
-  
+  expect_identical(
+    meta,
+    list(caption = "", report = TRUE, tag = "", notes = "")
+  )
+
   y <- data.frame(z = 2L)
   expect_identical(
     sbf_save_table(y, report = FALSE, caption = "A caption"),
@@ -754,7 +813,7 @@ test_that("table", {
   expect_identical(sbf_load_tables(), c("x", "y"))
   expect_identical(x, data.frame(x = 1))
   expect_identical(y, data.frame(z = 2L))
-  
+
   data <- sbf_load_tables_recursive()
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("tables", "name", "sub", "file"))
@@ -767,19 +826,25 @@ test_that("table", {
       file.path(sbf_get_main(), "tables/y.rds")
     )
   )
-  
+
   data2 <- sbf_load_tables_recursive(meta = TRUE)
   expect_identical(
     colnames(data2),
     c(
-      "tables", "name", "sub", "file",
-      "caption", "report", "tag", "notes"
+      "tables",
+      "name",
+      "sub",
+      "file",
+      "caption",
+      "report",
+      "tag",
+      "notes"
     )
   )
   expect_identical(data2[c("tables", "name", "sub", "file")], data)
   expect_identical(data2$caption, c("", "A caption"))
   expect_identical(data2$report, c(TRUE, FALSE))
-  
+
   expect_identical(data$tables[[1]], data.frame(x = 1))
   expect_identical(data$name, c("x", "y"))
   expect_identical(
@@ -789,11 +854,14 @@ test_that("table", {
       file.path(sbf_get_main(), "tables/y.rds")
     )
   )
-  
+
   chk::expect_chk_error(sbf_load_table("x2"))
   expect_identical(sbf_reset_sub(), character(0))
   expect_identical(sbf_load_table("x"), x)
-  expect_message(expect_identical(sbf_reset_sub(rm = TRUE, ask = FALSE), character(0)))
+  expect_message(expect_identical(
+    sbf_reset_sub(rm = TRUE, ask = FALSE),
+    character(0)
+  ))
   chk::expect_chk_error(sbf_load_table("x"))
   expect_identical(sbf_set_sub("sub"), "sub")
   expect_identical(
@@ -812,16 +880,16 @@ test_that("block", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   sbf_set_main(tempdir())
   y <- "two words"
   expect_warning(sbf_load_blocks(), "no blocks to load")
   expect_error(sbf_save_block(), "argument \"x\" is missing, with no default")
   expect_identical(sbf_save_block(y), file.path(sbf_get_main(), "blocks/y.rds"))
-  
+
   expect_true(file.exists(file.path(sbf_get_main(), "blocks/y.rds")))
   expect_false(file.exists(file.path(sbf_get_main(), "blocks/x2.rds")))
-  
+
   expect_identical(sbf_load_block("y"), "two words")
   expect_identical(
     list.files(file.path(sbf_get_main(), "blocks")),
@@ -829,7 +897,7 @@ test_that("block", {
   )
   txt <- readLines(file.path(sbf_get_main(), "blocks", "y.txt"), warn = FALSE)
   expect_equal(txt, "two words")
-  
+
   one <- "some code"
   expect_identical(
     sbf_save_block(one, tag = "R"),
@@ -840,7 +908,7 @@ test_that("block", {
   expect_identical(sbf_load_blocks(), c("one", "y"))
   expect_identical(one, "some code")
   expect_identical(y, "two words")
-  
+
   data <- sbf_load_blocks_recursive()
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("blocks", "name", "sub", "file"))
@@ -853,25 +921,34 @@ test_that("block", {
       file.path(sbf_get_main(), "blocks/y.rds")
     )
   )
-  
+
   data2 <- sbf_load_blocks_recursive(meta = TRUE)
   expect_identical(
     colnames(data2),
     c(
-      "blocks", "name", "sub", "file",
-      "caption", "report", "tag", "notes"
+      "blocks",
+      "name",
+      "sub",
+      "file",
+      "caption",
+      "report",
+      "tag",
+      "notes"
     )
   )
   expect_identical(data2[c("blocks", "name", "sub", "file")], data)
   expect_identical(data2$tag, c("R", ""))
-  
+
   data3 <- sbf_load_blocks_recursive(meta = TRUE, tag = "R")
   expect_identical(data3, data2[1, ])
-  
+
   chk::expect_chk_error(sbf_load_block("x2"))
   expect_identical(sbf_reset_sub(), character(0))
   expect_identical(sbf_load_block("y"), "two words")
-  expect_message(expect_identical(sbf_reset_sub(rm = TRUE, ask = FALSE), character(0)))
+  expect_message(expect_identical(
+    sbf_reset_sub(rm = TRUE, ask = FALSE),
+    character(0)
+  ))
   chk::expect_chk_error(sbf_load_block("x"))
   expect_identical(sbf_set_sub("sub"), "sub")
   expect_identical(
@@ -892,8 +969,10 @@ test_that("plot", {
   sbf_close_windows()
 
   y <- 1
-  expect_error(sbf_save_plot(y), "^`x` must inherit from S3 class 'ggplot'[.]$",
-               class = "chk_error"
+  expect_error(
+    sbf_save_plot(y),
+    "^`x` must inherit from S3 class 'ggplot'[.]$",
+    class = "chk_error"
   )
 
   x <- ggplot2::ggplot()
@@ -905,8 +984,10 @@ test_that("plot", {
   expect_false(file.exists(file.path(sbf_get_main(), "plots/x2.rds")))
 
   # x has no csv or xlsx because it has no main data or layers
-  expect_identical(list.files(file.path(sbf_get_main(), "plots")),
-                   c("x.png", "x.rds", "x.yaml"))
+  expect_identical(
+    list.files(file.path(sbf_get_main(), "plots")),
+    c("x.png", "x.rds", "x.yaml")
+  )
 
   y <- ggplot2::ggplot(
     data = data.frame(x = 1, y = 2, z = NA_real_),
@@ -914,7 +995,7 @@ test_that("plot", {
   )
   expect_identical(sbf_save_plot(y), file.path(sbf_get_main(), "plots/y.rds"))
   expect_false(file.exists(paste0(sbf_get_main(), "plots/y.csv")))
-  
+
   y <- ggplot2::ggplot(
     data = data.frame(x = 1:3, y = 2:4, z = NA_real_),
     ggplot2::aes(x = x, y = y)
@@ -924,24 +1005,40 @@ test_that("plot", {
     list.files(file.path(sbf_get_main(), "plots")),
     sort(c(
       # x has no csv or xlsx because it has no main data or layers
-      "x.png", "x.yaml", "x.rds",
+      "x.png",
+      "x.yaml",
+      "x.rds",
       # y has a csv and xlsx because it has main data despite having no layers
-      "y.csv", "y.png", "y.yaml", "y.rds", "y.xlsx"
+      "y.csv",
+      "y.png",
+      "y.yaml",
+      "y.rds",
+      "y.xlsx"
     ))
   )
-  expect_identical(read.csv(file.path(sbf_get_main(), "plots/y.csv")),
-                   data.frame(x = 1:3, y = 2:4))
+  expect_identical(
+    read.csv(file.path(sbf_get_main(), "plots/y.csv")),
+    data.frame(x = 1:3, y = 2:4)
+  )
 
   expect_identical(sbf_save_plot(y), file.path(sbf_get_main(), "plots/y.rds"))
   expect_true(all.equal(sbf_load_plot("y"), y))
-  expect_identical(sbf_load_plot_data("y"),
-                   data.frame(x = 1:3, y = 2:4, z = NA_real_))
-  expect_identical(read.csv(file.path(sbf_get_main(), "plots", "y.csv")),
-                   data.frame(x = 1:3, y = 2:4))
-  expect_identical(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "y.xlsx")),
-                   dplyr::tibble(x = as.numeric(1:3), y = as.numeric(2:4)))
-  expect_identical(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "y.xlsx")),
-                   "1_0_data")
+  expect_identical(
+    sbf_load_plot_data("y"),
+    data.frame(x = 1:3, y = 2:4, z = NA_real_)
+  )
+  expect_identical(
+    read.csv(file.path(sbf_get_main(), "plots", "y.csv")),
+    data.frame(x = 1:3, y = 2:4)
+  )
+  expect_identical(
+    readxl::read_xlsx(file.path(sbf_get_main(), "plots", "y.xlsx")),
+    dplyr::tibble(x = as.numeric(1:3), y = as.numeric(2:4))
+  )
+  expect_identical(
+    readxl::excel_sheets(file.path(sbf_get_main(), "plots", "y.xlsx")),
+    "1_0_data"
+  )
 
   expect_identical(sbf_load_plots_data(), c("x", "y"))
   expect_identical(x, data.frame())
@@ -958,20 +1055,39 @@ test_that("plot", {
     data = data.frame(x = c(2, 3), y = c(3, 2)),
     ggplot2::aes(x = x, y = y)
   )
-  expect_identical(sbf_save_plot( # saves last plot as "plot"
-    csv = 1L, dpi = 320L, caption = "one c",
-    report = FALSE, width = 2.55, height = 3L,
-    units = "cm"),
-    file.path(sbf_get_main(), "plots/plot.rds"))
+  expect_identical(
+    sbf_save_plot(
+      # saves last plot as "plot"
+      csv = 1L,
+      dpi = 320L,
+      caption = "one c",
+      report = FALSE,
+      width = 2.55,
+      height = 3L,
+      units = "cm"
+    ),
+    file.path(sbf_get_main(), "plots/plot.rds")
+  )
   expect_true(all.equal(sbf_load_plot("plot"), t))
 
   expect_identical(
     list.files(file.path(sbf_get_main(), "plots")),
     c(
-      "plot.png", "plot.rds", "plot.xlsx", "plot.yaml", # has data but no layers
-      "x.png", "x.rds", "x.yaml", # no data or layers
-      "y.csv", "y.png", "y.rds", "y.xlsx", "y.yaml", # has data but no layers
-      "z.png", "z.rds", "z.yaml" # dataset has only one row and no layers
+      "plot.png",
+      "plot.rds",
+      "plot.xlsx",
+      "plot.yaml", # has data but no layers
+      "x.png",
+      "x.rds",
+      "x.yaml", # no data or layers
+      "y.csv",
+      "y.png",
+      "y.rds",
+      "y.xlsx",
+      "y.yaml", # has data but no layers
+      "z.png",
+      "z.rds",
+      "z.yaml" # dataset has only one row and no layers
     )
   )
 
@@ -991,11 +1107,22 @@ test_that("plot", {
   )
 
   data2 <- sbf_load_plots_recursive(meta = TRUE)
-  expect_identical(colnames(data2), c(
-    "plots", "name", "sub", "file", "caption", "report",
-    "tag", "notes",
-    "width", "height", "dpi"
-  ))
+  expect_identical(
+    colnames(data2),
+    c(
+      "plots",
+      "name",
+      "sub",
+      "file",
+      "caption",
+      "report",
+      "tag",
+      "notes",
+      "width",
+      "height",
+      "dpi"
+    )
+  )
   expect_identical(data2$caption[1:2], c("one c", ""))
   expect_identical(data2$report[1:2], c(FALSE, TRUE))
   expect_equal(data2$width[1:2], c(1.003937, 6.000000))
@@ -1020,130 +1147,270 @@ test_that("plot", {
   # tests for checking that data for different layers save individually
   # and redundantly
   p_layers <- ggplot2::ggplot() +
-    ggplot2::facet_wrap(~ Species) +
+    ggplot2::facet_wrap(~Species) +
     ggplot2::geom_point(ggplot2::aes(mpg, cyl), datasets::mtcars) +
     ggplot2::geom_line(ggplot2::aes(mpg, cyl), datasets::mtcars) +
-    ggplot2::geom_line(ggplot2::aes(Sepal.Length, Petal.Length), datasets::iris) +
-    ggplot2::geom_smooth(ggplot2::aes(Sepal.Length, Petal.Length),
-                         datasets::iris, method = "loess", formula = y ~ x)
+    ggplot2::geom_line(
+      ggplot2::aes(Sepal.Length, Petal.Length),
+      datasets::iris
+    ) +
+    ggplot2::geom_smooth(
+      ggplot2::aes(Sepal.Length, Petal.Length),
+      datasets::iris,
+      method = "loess",
+      formula = y ~ x
+    )
 
-  expect_identical(sbf_save_plot(p_layers),
-                   file.path(sbf_get_main(), "plots", "p_layers.rds"))
+  expect_identical(
+    sbf_save_plot(p_layers),
+    file.path(sbf_get_main(), "plots", "p_layers.rds")
+  )
   expect_identical(
     list.files(file.path(sbf_get_main(), "plots")),
     c(
-      "p_layers.png", "p_layers.rds", "p_layers.xlsx", "p_layers.yaml", # has data & layers
-      "plot.png", "plot.rds", "plot.xlsx", "plot.yaml", # has data but no layers
-      "x.png", "x.rds", "x.yaml", # no data or layers
-      "y.csv", "y.png", "y.rds", "y.xlsx", "y.yaml", # has data but no layers
-      "z.png", "z.rds", "z.yaml" # has one-row data and no layers
+      "p_layers.png",
+      "p_layers.rds",
+      "p_layers.xlsx",
+      "p_layers.yaml", # has data & layers
+      "plot.png",
+      "plot.rds",
+      "plot.xlsx",
+      "plot.yaml", # has data but no layers
+      "x.png",
+      "x.rds",
+      "x.yaml", # no data or layers
+      "y.csv",
+      "y.png",
+      "y.rds",
+      "y.xlsx",
+      "y.yaml", # has data but no layers
+      "z.png",
+      "z.rds",
+      "z.yaml" # has one-row data and no layers
     )
   )
-  expect_equal(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_layers.xlsx")),
-               c("1_1_point", "1_2_line", "1_3_line", "1_4_smooth"))
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                                 "1_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[1]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL)))
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                                 "1_2_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[2]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL)))
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                                 "1_3_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[3]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL)))
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                                 "1_4_smooth"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[4]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(PANEL = as.character(PANEL)))
+  expect_equal(
+    readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_layers.xlsx")),
+    c("1_1_point", "1_2_line", "1_3_line", "1_4_smooth")
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+      "1_1_point"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[
+      1
+    ]]) |>
+      dplyr::tibble() |>
+      dplyr::mutate(PANEL = as.character(PANEL))
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+      "1_2_line"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[
+      2
+    ]]) |>
+      dplyr::tibble() |>
+      dplyr::mutate(PANEL = as.character(PANEL))
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+      "1_3_line"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[
+      3
+    ]]) |>
+      dplyr::tibble() |>
+      dplyr::mutate(PANEL = as.character(PANEL))
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+      "1_4_smooth"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_layers)@data[[
+      4
+    ]]) |>
+      dplyr::tibble() |>
+      dplyr::mutate(PANEL = as.character(PANEL))
+  )
 
-  expect_error( # datasets are redundant but different because of row order
+  expect_error(
+    # datasets are redundant but different because of row order
     expect_equal(
-      readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                        "1_1_point"),
-      readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                        "1_2_line")
+      readxl::read_xlsx(
+        file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+        "1_1_point"
       ),
-  "Expected `readxl::read_xlsx\\(...\\)` to equal `readxl::read_xlsx\\(...\\)`.")
+      readxl::read_xlsx(
+        file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+        "1_2_line"
+      )
+    ),
+    "Expected `readxl::read_xlsx\\(...\\)` to equal `readxl::read_xlsx\\(...\\)`."
+  )
 
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                                 "1_1_point") |>
-                 dplyr::select(x, y, PANEL) |>
-                 dplyr::arrange(x, y),
-               readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
-                                 "1_2_line") |>
-                 dplyr::select(x, y, PANEL) |>
-                 dplyr::arrange(x, y))
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+      "1_1_point"
+    ) |>
+      dplyr::select(x, y, PANEL) |>
+      dplyr::arrange(x, y),
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_layers.xlsx"),
+      "1_2_line"
+    ) |>
+      dplyr::select(x, y, PANEL) |>
+      dplyr::arrange(x, y)
+  )
 
   # tests for checking that data for different patchwork patches save
   # individually and redundantly
   p_patches <-
     patchwork:::`/.ggplot`(
       ggplot2:::`+`(
-        (ggplot2::ggplot(datasets::mtcars) + ggplot2::geom_line(ggplot2::aes(mpg, cyl, color = cyl))),
-        (ggplot2::ggplot() + ggplot2::geom_line(ggplot2::aes(Sepal.Length, Petal.Length), datasets::iris))
+        (ggplot2::ggplot(datasets::mtcars) +
+          ggplot2::geom_line(ggplot2::aes(mpg, cyl, color = cyl))),
+        (ggplot2::ggplot() +
+          ggplot2::geom_line(
+            ggplot2::aes(Sepal.Length, Petal.Length),
+            datasets::iris
+          ))
       ),
       ggplot2:::`+`(
-        (ggplot2::ggplot() + ggplot2::geom_point(ggplot2::aes(mpg, cyl, color = cyl), datasets::mtcars)),
+        (ggplot2::ggplot() +
+          ggplot2::geom_point(
+            ggplot2::aes(mpg, cyl, color = cyl),
+            datasets::mtcars
+          )),
         ggplot2:::`+`(
-          (ggplot2::ggplot(datasets::iris) + ggplot2::geom_point(ggplot2::aes(Sepal.Length, Petal.Length))),
-          (ggplot2::ggplot() + ggplot2::geom_point(ggplot2::aes(Sepal.Length, Petal.Length, color = Species), datasets::iris)))
+          (ggplot2::ggplot(datasets::iris) +
+            ggplot2::geom_point(ggplot2::aes(Sepal.Length, Petal.Length))),
+          (ggplot2::ggplot() +
+            ggplot2::geom_point(
+              ggplot2::aes(Sepal.Length, Petal.Length, color = Species),
+              datasets::iris
+            ))
+        )
       )
     )
 
-  expect_identical(sbf_save_plot(p_patches),
-                   file.path(sbf_get_main(), "plots", "p_patches.rds"))
+  expect_identical(
+    sbf_save_plot(p_patches),
+    file.path(sbf_get_main(), "plots", "p_patches.rds")
+  )
   expect_identical(
     list.files(file.path(sbf_get_main(), "plots")),
     c(
-      "p_layers.png", "p_layers.rds", "p_layers.xlsx", "p_layers.yaml", # has data & layers
-      "p_patches.csv", "p_patches.png", "p_patches.rds", "p_patches.xlsx", "p_patches.yaml",
-      "plot.png", "plot.rds", "plot.xlsx", "plot.yaml", # has data but no layers
-      "x.png", "x.rds", "x.yaml", # no data or layers
-      "y.csv", "y.png", "y.rds", "y.xlsx", "y.yaml", # has data but no layers
-      "z.png", "z.rds", "z.yaml" # has one-row data and no layers
+      "p_layers.png",
+      "p_layers.rds",
+      "p_layers.xlsx",
+      "p_layers.yaml", # has data & layers
+      "p_patches.csv",
+      "p_patches.png",
+      "p_patches.rds",
+      "p_patches.xlsx",
+      "p_patches.yaml",
+      "plot.png",
+      "plot.rds",
+      "plot.xlsx",
+      "plot.yaml", # has data but no layers
+      "x.png",
+      "x.rds",
+      "x.yaml", # no data or layers
+      "y.csv",
+      "y.png",
+      "y.rds",
+      "y.xlsx",
+      "y.yaml", # has data but no layers
+      "z.png",
+      "z.rds",
+      "z.yaml" # has one-row data and no layers
     )
   )
-  expect_equal(readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_patches.xlsx")),
-               c("1_0_data", "1_1_line",
-                 "2_1_line",
-                 "3_1_point",
-                 "4_0_data", "4_1_point",
-                 "5_1_point"))
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
-                                 "1_0_data"),
-               dplyr::tibble(datasets::mtcars))
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
-                                 "1_1_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[1]])@data[[1]]) |>
-                 dplyr::tibble())
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
-                                 "2_1_line"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[2]])@data[[1]]) |>
-                 dplyr::tibble())
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
-                                 "3_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[1]])@data[[1]]) |>
-                 dplyr::tibble())
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
-                                 "4_0_data"),
-               dplyr::tibble(datasets::iris) |>
-                 dplyr::mutate(Species = as.character(Species)))
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
-                                 "4_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[2]][[1]])@data[[1]]) |>
-                 dplyr::tibble())
-  expect_equal(readxl::read_xlsx(file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
-                                 "5_1_point"),
-               tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[2]][[2]])@data[[1]]) |>
-                 dplyr::tibble() |>
-                 dplyr::mutate(group = `attr<-`(group, "n", NULL)))
-  
+  expect_equal(
+    readxl::excel_sheets(file.path(sbf_get_main(), "plots", "p_patches.xlsx")),
+    c(
+      "1_0_data",
+      "1_1_line",
+      "2_1_line",
+      "3_1_point",
+      "4_0_data",
+      "4_1_point",
+      "5_1_point"
+    )
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
+      "1_0_data"
+    ),
+    dplyr::tibble(datasets::mtcars)
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
+      "1_1_line"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[
+      1
+    ]])@data[[1]]) |>
+      dplyr::tibble()
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
+      "2_1_line"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[1]][[
+      2
+    ]])@data[[1]]) |>
+      dplyr::tibble()
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
+      "3_1_point"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[
+      1
+    ]])@data[[1]]) |>
+      dplyr::tibble()
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
+      "4_0_data"
+    ),
+    dplyr::tibble(datasets::iris) |>
+      dplyr::mutate(Species = as.character(Species))
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
+      "4_1_point"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[
+      2
+    ]][[1]])@data[[1]]) |>
+      dplyr::tibble()
+  )
+  expect_equal(
+    readxl::read_xlsx(
+      file.path(sbf_get_main(), "plots", "p_patches.xlsx"),
+      "5_1_point"
+    ),
+    tidyplus::drop_uninformative_columns(ggplot2::ggplot_build(p_patches[[2]][[
+      2
+    ]][[2]])@data[[1]]) |>
+      dplyr::tibble() |>
+      dplyr::mutate(group = `attr<-`(group, "n", NULL))
+  )
+
   sbf_reset()
   sbf_close_windows()
 })
@@ -1164,33 +1431,35 @@ test_that("`sbf_load_plots_recursive()` loads all possible plots when `drop = NU
   p3 <- ggplot2::ggplot() +
     ggplot2::geom_point(ggplot2::aes(3, 3)) +
     ggplot2::ggtitle("Plot 3")
-  
+
   temp_dir <- withr::local_tempdir("test-files-", tmpdir = ".")
-  
+
   sbf_save_plot(x = p1, x_name = "plot-1", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p2, x_name = "plot-2", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p3, x_name = "plot-3", sub = "sub", main = temp_dir)
-  
+
   input <- sbf_load_plots_recursive(sub = "sub", main = temp_dir)
-  
+
   expect_equal(nrow(input), 3L)
   expect_s3_class(input$plots[[1]], "ggplot")
   expect_equal(input$plots[[1]]@labels$title, p1@labels$title)
   expect_equal(input$plots[[2]]@labels$title, p2@labels$title)
   expect_equal(input$plots[[3]]@labels$title, p3@labels$title)
-  
-  input <- sbf_load_plots_recursive(sub = "sub", main = temp_dir,
-                                    drop = "")
-  
+
+  input <- sbf_load_plots_recursive(sub = "sub", main = temp_dir, drop = "")
+
   expect_equal(nrow(input), 3L)
   expect_s3_class(input$plots[[1]], "ggplot")
   expect_equal(input$plots[[1]]@labels$title, p1@labels$title)
   expect_equal(input$plots[[2]]@labels$title, p2@labels$title)
   expect_equal(input$plots[[3]]@labels$title, p3@labels$title)
-  
-  input <- sbf_load_plots_recursive(sub = "sub", main = temp_dir,
-                                    drop = character(0))
-  
+
+  input <- sbf_load_plots_recursive(
+    sub = "sub",
+    main = temp_dir,
+    drop = character(0)
+  )
+
   expect_equal(nrow(input), 3L)
   expect_s3_class(input$plots[[1]], "ggplot")
   expect_equal(input$plots[[1]]@labels$title, p1@labels$title)
@@ -1208,15 +1477,19 @@ test_that("`sbf_load_plots_recursive()` only loads plot that do not match the pa
   p3 <- ggplot2::ggplot() +
     ggplot2::geom_point(ggplot2::aes(3, 3)) +
     ggplot2::ggtitle("Plot 3")
-  
+
   temp_dir <- withr::local_tempdir("test-files-", tmpdir = ".")
-  
+
   sbf_save_plot(x = p1, x_name = "plot-1", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p2, x_name = "plot-2", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p3, x_name = "plot-3", sub = "sub", main = temp_dir)
-  
-  input <- sbf_load_plots_recursive(sub = "sub", main = temp_dir, drop = "plot-3")
-  
+
+  input <- sbf_load_plots_recursive(
+    sub = "sub",
+    main = temp_dir,
+    drop = "plot-3"
+  )
+
   expect_equal(input$plots[[1]]@labels$title, p1@labels$title)
   expect_equal(input$plots[[2]]@labels$title, p2@labels$title)
   expect_equal(nrow(input), length(c(1, 2)))
@@ -1224,37 +1497,61 @@ test_that("`sbf_load_plots_recursive()` only loads plot that do not match the pa
 
 test_that("`sbf_load_plots_recursive()` drops relevant plots *before* loading them.", {
   p <- ggplot2::ggplot() + ggplot2::geom_point(ggplot2::aes(1, 1))
-  
+
   temp_dir <- withr::local_tempdir("test-files-", tmpdir = ".")
-  
-  i <- vapply(1:3, function(i) {
-    sbf_save_plot(x = p + ggplot2::ggtitle(paste("Plot", i)),
-                  x_name = paste0("plot-", i),
-                  sub = paste0("sub", i), main = temp_dir)
-    return(i)
-  }, integer(1))
-  
-  t_dropped <- suppressWarnings(microbenchmark::microbenchmark({
-    plot_subset <- sbf_load_plots_recursive(main = temp_dir, drop = c("sub1", "sub2"))
-  }, unit = "millisecond"))
-  
-  t_all <- suppressWarnings(microbenchmark::microbenchmark({
-    plot_all <- sbf_load_plots_recursive(main = temp_dir)
-  }, unit = "millisecond"))
-  
+
+  i <- vapply(
+    1:3,
+    function(i) {
+      sbf_save_plot(
+        x = p + ggplot2::ggtitle(paste("Plot", i)),
+        x_name = paste0("plot-", i),
+        sub = paste0("sub", i),
+        main = temp_dir
+      )
+      return(i)
+    },
+    integer(1)
+  )
+
+  t_dropped <- suppressWarnings(microbenchmark::microbenchmark(
+    {
+      plot_subset <- sbf_load_plots_recursive(
+        main = temp_dir,
+        drop = c("sub1", "sub2")
+      )
+    },
+    unit = "millisecond"
+  ))
+
+  t_all <- suppressWarnings(microbenchmark::microbenchmark(
+    {
+      plot_all <- sbf_load_plots_recursive(main = temp_dir)
+    },
+    unit = "millisecond"
+  ))
+
   expect_lt(median(t_dropped$time), median(t_all$time))
   expect_lt(nrow(plot_subset), nrow(plot_all))
 })
 
 test_that("`sbf_load_plots_recursive()` returns an error if `drop` is not `NULL` or a character vector with non-empty strings.", {
-  expect_error(sbf_load_plots_recursive(drop = 1),
-               regexp = "`drop` must be character or NULL.")
-  expect_error(sbf_load_plots_recursive(drop = NA),
-               regexp = "`drop` must be character or NULL.")
-  expect_error(sbf_load_plots_recursive(drop = data.frame()),
-               regexp = "`drop` must be character or NULL.")
-  expect_error(sbf_load_plots_recursive(drop = NA_character_),
-               regexp = "`drop` must not have any missing values.")
+  expect_error(
+    sbf_load_plots_recursive(drop = 1),
+    regexp = "`drop` must be character or NULL."
+  )
+  expect_error(
+    sbf_load_plots_recursive(drop = NA),
+    regexp = "`drop` must be character or NULL."
+  )
+  expect_error(
+    sbf_load_plots_recursive(drop = data.frame()),
+    regexp = "`drop` must be character or NULL."
+  )
+  expect_error(
+    sbf_load_plots_recursive(drop = NA_character_),
+    regexp = "`drop` must not have any missing values."
+  )
 })
 
 test_that("`sbf_load_plots_recursive()` returns a table with no rows if no objects are in the sub.", {
@@ -1268,7 +1565,7 @@ test_that("sbf_load_plots_recursive() fails if at least one sub is populated and
   temp_dir <- withr::local_tempdir(pattern = "test-files-", tmpdir = ".")
   temp_dir <- gsub("./", "", temp_dir, fixed = TRUE)
   sbf_set_main(temp_dir)
-  
+
   p1 <- ggplot2::ggplot() +
     ggplot2::geom_point(ggplot2::aes(1, 1)) +
     ggplot2::ggtitle("Plot 1")
@@ -1278,52 +1575,78 @@ test_that("sbf_load_plots_recursive() fails if at least one sub is populated and
   p3 <- ggplot2::ggplot() +
     ggplot2::geom_point(ggplot2::aes(3, 3)) +
     ggplot2::ggtitle("Plot 3")
-  
-  expect_identical(sbf_load_plots_recursive(main = "nonexistent"),
-                   tibble(plots = list(), name = character(0),
-                          sub = character(0), file = character(0)))
-  
-  expect_identical(sbf_load_plots_recursive(main = "nonexistent", sub = "nope"),
-                   tibble(plots = list(), name = character(0),
-                          sub = character(0), file = character(0)))
-  
+
+  expect_identical(
+    sbf_load_plots_recursive(main = "nonexistent"),
+    tibble(
+      plots = list(),
+      name = character(0),
+      sub = character(0),
+      file = character(0)
+    )
+  )
+
+  expect_identical(
+    sbf_load_plots_recursive(main = "nonexistent", sub = "nope"),
+    tibble(
+      plots = list(),
+      name = character(0),
+      sub = character(0),
+      file = character(0)
+    )
+  )
+
   dir.create(paste0(sbf_get_main(), '/plots/sub'), recursive = TRUE)
-  
+
   # succeeds because the "sub" sub is empty
-  expect_equal(sbf_load_plots_recursive(main = temp_dir, drop = "sub"),
-               tibble(plots = list(), name = character(0),
-                      sub = character(0), file = character(0)))
-  
+  expect_equal(
+    sbf_load_plots_recursive(main = temp_dir, drop = "sub"),
+    tibble(
+      plots = list(),
+      name = character(0),
+      sub = character(0),
+      file = character(0)
+    )
+  )
+
   sbf_save_plot(x = p1, x_name = "plot-1", sub = "sub", main = temp_dir)
-  expect_equal(sbf_load_plots_recursive(sub = "", main = temp_dir, drop = "sub"),
-               tibble(plots = list(), name = character(0),
-                      sub = character(0), file = character(0)))
-  
+  expect_equal(
+    sbf_load_plots_recursive(sub = "", main = temp_dir, drop = "sub"),
+    tibble(
+      plots = list(),
+      name = character(0),
+      sub = character(0),
+      file = character(0)
+    )
+  )
+
   sbf_save_plot(x = p2, x_name = "plot-2", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p3, x_name = "plot-3", sub = "sub", main = temp_dir)
   sbf_save_plot(x = p2, x_name = "plot-2", sub = "sub2", main = temp_dir)
   sbf_save_plot(x = p3, x_name = "plot-3", sub = "sub3", main = temp_dir)
-  
+
   expect_snapshot({
     out <- sbf_load_plots_recursive(main = temp_dir)
     out$file <- NULL
-    out})
-  
+    out
+  })
+
   expect_snapshot({
     out <- sbf_load_plots_recursive(main = temp_dir, drop = "sub")
     out$file <- NULL
-    out})
+    out
+  })
 })
 
 test_that("window", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   sbf_close_windows()
   withr::defer(sbf_close_windows())
   expect_error(sbf_save_window(), "^No such device[.]$")
-  
+
   skip("run locally as uses screen devices")
   expect_identical(sbf_reset_main(rm = TRUE, ask = FALSE), "output")
   sbf_open_window()
@@ -1337,13 +1660,21 @@ test_that("window", {
     list.files(file.path(sbf_get_main(), "windows")),
     sort(c("window.yaml", "window.png"))
   )
-  
+
   meta <- yaml::read_yaml(file.path(sbf_get_main(), "windows", "window.yaml"))
-  expect_identical(meta, list(
-    caption = "", report = TRUE, tag = "", notes = "",
-    width = 6, height = 7, dpi = 300
-  ))
-  
+  expect_identical(
+    meta,
+    list(
+      caption = "",
+      report = TRUE,
+      tag = "",
+      notes = "",
+      width = 6,
+      height = 7,
+      dpi = 300
+    )
+  )
+
   gp <- ggplot2::ggplot(
     data = data.frame(x = c(4, 5), y = c(6, 7)),
     ggplot2::aes(x = x, y = y)
@@ -1355,31 +1686,48 @@ test_that("window", {
     sbf_save_window("t2", dpi = 72, caption = "nice one", report = FALSE),
     file.path(sbf_get_main(), "windows/t2.png")
   )
-  
+
   expect_identical(
     list.files(file.path(sbf_get_main(), "windows")),
     sort(c("t2.yaml", "window.yaml", "t2.png", "window.png"))
   )
-  
+
   meta <- yaml::read_yaml(file.path(sbf_get_main(), "windows", "t2.yaml"))
-  expect_identical(meta, list(
-    caption = "nice one", report = FALSE, tag = "", notes = "",
-    width = 4, height = 3, dpi = 72
-  ))
-  
+  expect_identical(
+    meta,
+    list(
+      caption = "nice one",
+      report = FALSE,
+      tag = "",
+      notes = "",
+      width = 4,
+      height = 3,
+      dpi = 72
+    )
+  )
+
   data <- sbf_load_windows_recursive(sub = character(0))
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("windows", "name", "file"))
   expect_identical(data$name, c("t2", "window"))
   expect_identical(data$windows[1], "output/windows/t2.png")
   expect_identical(data$windows, data$file)
-  
+
   data2 <- sbf_load_windows_recursive(sub = character(0), meta = TRUE)
-  
-  expect_identical(colnames(data2), c(
-    "windows", "name", "file", "caption",
-    "report", "width", "height", "dpi"
-  ))
+
+  expect_identical(
+    colnames(data2),
+    c(
+      "windows",
+      "name",
+      "file",
+      "caption",
+      "report",
+      "width",
+      "height",
+      "dpi"
+    )
+  )
   expect_identical(data2[c("windows", "name", "file")], data)
   expect_identical(data2$caption, c("nice one", ""))
   expect_identical(data2$report, c(FALSE, TRUE))
@@ -1392,37 +1740,58 @@ test_that("png", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
-  x <- system.file("extdata",
-                   "example.png",
-                   package = "subfoldr2",
-                   mustWork = TRUE
+
+  x <- system.file(
+    "extdata",
+    "example.png",
+    package = "subfoldr2",
+    mustWork = TRUE
   )
-  
+
   sbf_save_png(x, caption = "map")
-  
+
   expect_identical(
     list.files(file.path(sbf_get_main(), "windows")),
     sort(c("example.yaml", "example.png"))
   )
-  
+
   meta <- yaml::read_yaml(file.path(sbf_get_main(), "windows", "example.yaml"))
-  expect_identical(meta, list(
-    caption = "map", report = TRUE, tag = "", notes = "",
-    width = 6, height = 5.992, dpi = 125
-  ))
-  
+  expect_identical(
+    meta,
+    list(
+      caption = "map",
+      report = TRUE,
+      tag = "",
+      notes = "",
+      width = 6,
+      height = 5.992,
+      dpi = 125
+    )
+  )
+
   data <- sbf_load_windows_recursive(sub = character(0))
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("windows", "name", "sub", "file"))
   expect_identical(data$name, c("example"))
-  
+
   data <- sbf_load_windows_recursive(sub = character(0), meta = TRUE)
   expect_s3_class(data, "tbl_df")
-  expect_identical(colnames(data), c(
-    "windows", "name", "sub", "file", "caption", "report", "tag", "notes",
-    "width", "height", "dpi"
-  ))
+  expect_identical(
+    colnames(data),
+    c(
+      "windows",
+      "name",
+      "sub",
+      "file",
+      "caption",
+      "report",
+      "tag",
+      "notes",
+      "width",
+      "height",
+      "dpi"
+    )
+  )
   expect_identical(data$name, c("example"))
 })
 
@@ -1430,38 +1799,59 @@ test_that("png2", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
-  x <- system.file("extdata",
-                   "example.png",
-                   package = "subfoldr2",
-                   mustWork = TRUE
+
+  x <- system.file(
+    "extdata",
+    "example.png",
+    package = "subfoldr2",
+    mustWork = TRUE
   )
-  
+
   sbf_save_png(x, caption = "map")
   sbf_save_png(x, x_name = "x2", caption = "map2")
-  
+
   expect_identical(
     list.files(file.path(sbf_get_main(), "windows")),
     sort(c("example.yaml", "example.png", "x2.png", "x2.yaml"))
   )
-  
+
   meta <- yaml::read_yaml(file.path(sbf_get_main(), "windows", "example.yaml"))
-  expect_identical(meta, list(
-    caption = "map", report = TRUE, tag = "", notes = "",
-    width = 6, height = 5.992, dpi = 125
-  ))
-  
+  expect_identical(
+    meta,
+    list(
+      caption = "map",
+      report = TRUE,
+      tag = "",
+      notes = "",
+      width = 6,
+      height = 5.992,
+      dpi = 125
+    )
+  )
+
   data <- sbf_load_windows_recursive(sub = character(0))
   expect_s3_class(data, "tbl_df")
   expect_identical(colnames(data), c("windows", "name", "sub", "file"))
   expect_identical(data$name, c("example", "x2"))
-  
+
   data <- sbf_load_windows_recursive(sub = character(0), meta = TRUE)
   expect_s3_class(data, "tbl_df")
-  expect_identical(colnames(data), c(
-    "windows", "name", "sub", "file", "caption", "report", "tag", "notes",
-    "width", "height", "dpi"
-  ))
+  expect_identical(
+    colnames(data),
+    c(
+      "windows",
+      "name",
+      "sub",
+      "file",
+      "caption",
+      "report",
+      "tag",
+      "notes",
+      "width",
+      "height",
+      "dpi"
+    )
+  )
   expect_identical(data$name, c("example", "x2"))
 })
 
@@ -1472,7 +1862,7 @@ test_that("load_rdss_recursive() lists non-rds files without reading them", {
 
   sbf_save_table(data.frame(z = 1L), x_name = "x", caption = "cap")
   sbf_save_table(data.frame(z = 1L), x_name = "x2", caption = "cap")
-  
+
   # non-rds extensions (e.g. yaml metadata) are listed but not deserialized,
   # so this does not attempt readRDS() on a yaml file
   data <- load_rdss_recursive(class = "tables", ext = "yaml")
@@ -1485,11 +1875,11 @@ test_that("save table glue", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(x = 1)
   sbf_save_table(data, caption = "character")
   sbf_save_table(data, x_name = "data2", caption = glue::glue("glue"))
-  
+
   expect_identical(
     sbf_load_tables_recursive(meta = TRUE)$caption,
     c("character", "glue")
@@ -1501,14 +1891,14 @@ test_that("save df as excel no sf columns", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing")
   )
   sbf_save_excel(data)
   data_test <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
-  
+
   expect_identical(colnames(data_test), c("Places", "Activity"))
   expect_identical(data[["Places"]], c("Yakoun Lake", "Meyer Lake"))
   expect_identical(data[["Activity"]], c("boating", "fishing"))
@@ -1519,23 +1909,28 @@ test_that("save df as excel with sf point column", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
     X = c(53.350808, 53.640981),
     Y = c(-132.280579, -132.055175)
   )
-  
+
   data <- convert_coords_to_sfc(data)
-  
+
   sbf_save_excel(data)
   data <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
-  
-  expect_identical(colnames(data), c(
-    "Places", "Activity",
-    "geometry_X", "geometry_Y"
-  ))
+
+  expect_identical(
+    colnames(data),
+    c(
+      "Places",
+      "Activity",
+      "geometry_X",
+      "geometry_Y"
+    )
+  )
   expect_identical(data[["Places"]], c("Yakoun Lake", "Meyer Lake"))
   expect_identical(data[["Activity"]], c("boating", "fishing"))
   expect_equal(data[["geometry_X"]], c(53.350808, 53.640981))
@@ -1547,7 +1942,7 @@ test_that("save df as excel with multiple sf point columns", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
@@ -1556,21 +1951,28 @@ test_that("save df as excel with multiple sf point columns", {
     X2 = c(53.350808, 53.640981),
     Y2 = c(-132.280579, -132.055175)
   )
-  
+
   data <- convert_coords_to_sfc(data)
-  data <- convert_coords_to_sfc(data,
-                                coords = c("X2", "Y2"),
-                                sfc_name = "geometry2"
+  data <- convert_coords_to_sfc(
+    data,
+    coords = c("X2", "Y2"),
+    sfc_name = "geometry2"
   )
-  
+
   sbf_save_excel(data)
   data <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
-  
-  expect_identical(colnames(data), c(
-    "Places", "Activity",
-    "geometry_X", "geometry_Y",
-    "geometry2_X", "geometry2_Y"
-  ))
+
+  expect_identical(
+    colnames(data),
+    c(
+      "Places",
+      "Activity",
+      "geometry_X",
+      "geometry_Y",
+      "geometry2_X",
+      "geometry2_Y"
+    )
+  )
   expect_identical(data[["Places"]], c("Yakoun Lake", "Meyer Lake"))
   expect_identical(data[["Activity"]], c("boating", "fishing"))
   expect_equal(data[["geometry_X"]], c(53.350808, 53.640981))
@@ -1584,7 +1986,7 @@ test_that("save df as excel with multiple sf linstring columns", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
@@ -1593,20 +1995,21 @@ test_that("save df as excel with multiple sf linstring columns", {
     X2 = c(53.350808, 53.640981),
     Y2 = c(-132.280579, -132.055175)
   )
-  
+
   data <- convert_coords_to_sfc(data)
-  data <- convert_coords_to_sfc(data,
-                                coords = c("X2", "Y2"),
-                                sfc_name = "geometry2"
+  data <- convert_coords_to_sfc(
+    data,
+    coords = c("X2", "Y2"),
+    sfc_name = "geometry2"
   )
-  
+
   data <- sf::st_cast(data, "LINESTRING")
   data <- sf::st_set_geometry(data, "geometry")
   data <- sf::st_cast(data, "LINESTRING")
-  
+
   sbf_save_excel(data)
   data <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
-  
+
   expect_identical(colnames(data), c("Places", "Activity"))
 })
 
@@ -1615,7 +2018,7 @@ test_that("save df as excel with linstring column and sf point", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
@@ -1624,22 +2027,28 @@ test_that("save df as excel with linstring column and sf point", {
     X2 = c(53.350808, 53.640981),
     Y2 = c(-132.280579, -132.055175)
   )
-  
+
   data <- convert_coords_to_sfc(data)
-  data <- convert_coords_to_sfc(data,
-                                coords = c("X2", "Y2"),
-                                sfc_name = "geometry2"
+  data <- convert_coords_to_sfc(
+    data,
+    coords = c("X2", "Y2"),
+    sfc_name = "geometry2"
   )
-  
+
   data <- sf::st_cast(data, "LINESTRING")
-  
+
   sbf_save_excel(data)
   data <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
-  
-  expect_identical(colnames(data), c(
-    "Places", "Activity",
-    "geometry_X", "geometry_Y"
-  ))
+
+  expect_identical(
+    colnames(data),
+    c(
+      "Places",
+      "Activity",
+      "geometry_X",
+      "geometry_Y"
+    )
+  )
 })
 
 test_that("save df as excel with blob column", {
@@ -1647,7 +2056,7 @@ test_that("save df as excel with blob column", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   expect_output(
     data <- data.frame(
       Places = c("Yakoun Lake", "Meyer Lake"),
@@ -1658,10 +2067,10 @@ test_that("save df as excel with blob column", {
       )
     )
   )
-  
+
   sbf_save_excel(data)
   data <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
-  
+
   expect_identical(colnames(data), c("Places", "Activity"))
   expect_identical(data[["Places"]], c("Yakoun Lake", "Meyer Lake"))
   expect_identical(data[["Activity"]], c("boating", "fishing"))
@@ -1672,7 +2081,7 @@ test_that("checking return value for sbf_save_excel", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(x = seq(100))
   return_path <- sbf_save_excel(data)
   expect_match(return_path, "output/excel/data.xlsx$")
@@ -1680,83 +2089,83 @@ test_that("checking return value for sbf_save_excel", {
 
 test_that("two spreadsheets are created due to long table with correct sheet
           pairing", {
-            sbf_reset()
-            path <- file.path(withr::local_tempdir(), "output")
-            sbf_set_main(path)
-            withr::defer(sbf_reset())
-            
-            data <- data.frame(x = seq(2097150))
-            sbf_save_excel(data, max_sheets = 2L)
-            
-            data_1 <- readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 1
-            )
-            data_2 <- readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 2
-            )
-            
-            expect_error(readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 3
-            ))
-            
-            expect_equal(nrow(data_1), 1048575L)
-            expect_equal(nrow(data_2), 1048575L)
-          })
+  sbf_reset()
+  path <- file.path(withr::local_tempdir(), "output")
+  sbf_set_main(path)
+  withr::defer(sbf_reset())
+
+  data <- data.frame(x = seq(2097150))
+  sbf_save_excel(data, max_sheets = 2L)
+
+  data_1 <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 1
+  )
+  data_2 <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 2
+  )
+
+  expect_error(readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 3
+  ))
+
+  expect_equal(nrow(data_1), 1048575L)
+  expect_equal(nrow(data_2), 1048575L)
+})
 
 test_that("two spreadsheets are created due to long table when only 1 sheet
           requested", {
-            sbf_reset()
-            path <- file.path(withr::local_tempdir(), "output")
-            sbf_set_main(path)
-            withr::defer(sbf_reset())
-            
-            data <- data.frame(x = seq(2097150))
-            sbf_save_excel(data, max_sheets = 1L)
-            
-            data_1 <- readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 1
-            )
-            
-            expect_error(readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 2
-            ))
-            
-            expect_equal(nrow(data_1), 1048575L)
-          })
+  sbf_reset()
+  path <- file.path(withr::local_tempdir(), "output")
+  sbf_set_main(path)
+  withr::defer(sbf_reset())
+
+  data <- data.frame(x = seq(2097150))
+  sbf_save_excel(data, max_sheets = 1L)
+
+  data_1 <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 1
+  )
+
+  expect_error(readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 2
+  ))
+
+  expect_equal(nrow(data_1), 1048575L)
+})
 
 test_that("two spreadsheets are created due to long table when extra sheets
           requested", {
-            sbf_reset()
-            path <- file.path(withr::local_tempdir(), "output")
-            sbf_set_main(path)
-            withr::defer(sbf_reset())
-            
-            data <- data.frame(x = seq(2097150))
-            sbf_save_excel(data, max_sheets = 5L)
-            
-            data_1 <- readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 1
-            )
-            
-            data_2 <- readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 2
-            )
-            
-            expect_error(readxl::read_excel(
-              file.path(path, "excel/data.xlsx"),
-              sheet = 3
-            ))
-            
-            expect_equal(nrow(data_1), 1048575L)
-            expect_equal(nrow(data_2), 1048575L)
-          })
+  sbf_reset()
+  path <- file.path(withr::local_tempdir(), "output")
+  sbf_set_main(path)
+  withr::defer(sbf_reset())
+
+  data <- data.frame(x = seq(2097150))
+  sbf_save_excel(data, max_sheets = 5L)
+
+  data_1 <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 1
+  )
+
+  data_2 <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 2
+  )
+
+  expect_error(readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 3
+  ))
+
+  expect_equal(nrow(data_1), 1048575L)
+  expect_equal(nrow(data_2), 1048575L)
+})
 
 
 test_that("save two tables from the environment to separate excel files", {
@@ -1764,25 +2173,27 @@ test_that("save two tables from the environment to separate excel files", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   sites <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing")
   )
-  
+
   species <- data.frame(
     Species = c("Rainbow Trout", "Coho"),
     Code = c("RT", "CO")
   )
-  
-  sbf_save_excels(env = as.environment(list(
-    sites = sites,
-    species = species
-  )))
-  
+
+  sbf_save_excels(
+    env = as.environment(list(
+      sites = sites,
+      species = species
+    ))
+  )
+
   site_data <- readxl::read_excel(file.path(path, "excel/sites.xlsx"))
   species_data <- readxl::read_excel(file.path(path, "excel/species.xlsx"))
-  
+
   expect_identical(colnames(site_data), c("Places", "Activity"))
   expect_identical(colnames(species_data), c("Species", "Code"))
 })
@@ -1792,10 +2203,10 @@ test_that("checking return value for sbf_save_excels", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(x = seq(100))
   return_path <- sbf_save_excels(env = as.environment(list(data = data)))
-  
+
   expect_match(return_path, "output/excel/data.xlsx$")
 })
 
@@ -1804,26 +2215,28 @@ test_that("save two dataframes as excel workbook", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   sites <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing")
   )
-  
+
   species <- data.frame(
     Species = c("Rainbow Trout", "Coho"),
     Code = c("RT", "CO")
   )
-  
+
   sbf_save_workbook("data")
-  
-  site_data <- readxl::read_excel(file.path(path, "excel/data.xlsx"),
-                                  sheet = "sites"
+
+  site_data <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = "sites"
   )
-  species_data <- readxl::read_excel(file.path(path, "excel/data.xlsx"),
-                                     sheet = "species"
+  species_data <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = "species"
   )
-  
+
   expect_identical(colnames(site_data), c("Places", "Activity"))
   expect_identical(colnames(species_data), c("Species", "Code"))
 })
@@ -1833,10 +2246,10 @@ test_that("checking return value for sbf_save_workbook", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(x = seq(100))
   return_path <- sbf_save_workbook("data")
-  
+
   expect_match(return_path, "output/excel/data.xlsx$")
 })
 
@@ -1845,41 +2258,47 @@ test_that("database can be written to excel workbook", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   # create test data
   sites <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing")
   )
-  
+
   species <- data.frame(
     Species = c("Rainbow Trout", "Coho"),
     Caught = c(5, 2)
   )
-  
+
   sbf_create_db(db_name = "database")
-  
-  sbf_execute_db("CREATE TABLE species (
+
+  sbf_execute_db(
+    "CREATE TABLE species (
                 Species TEXT,
-                Caught INTEGER)")
-  
-  sbf_execute_db("CREATE TABLE sites (
+                Caught INTEGER)"
+  )
+
+  sbf_execute_db(
+    "CREATE TABLE sites (
                 Places TEXT,
-                Activity TEXT)")
-  
+                Activity TEXT)"
+  )
+
   sbf_save_data_to_db(sites, db_name = "database")
   sbf_save_data_to_db(species, db_name = "database")
-  
+
   # write db to excel tables
   sbf_save_db_to_workbook(workbook_name = "data", db_name = "database")
   # do tests
-  site_data <- readxl::read_excel(file.path(path, "excel/data.xlsx"),
-                                  sheet = "sites"
+  site_data <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = "sites"
   )
-  species_data <- readxl::read_excel(file.path(path, "excel/data.xlsx"),
-                                     sheet = "species"
+  species_data <- readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = "species"
   )
-  
+
   expect_identical(colnames(site_data), c("Places", "Activity"))
   expect_identical(colnames(species_data), c("Species", "Caught"))
 })
@@ -1889,31 +2308,35 @@ test_that("exclude table function working for db to workbook", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   # create test data
   sites <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing")
   )
-  
+
   species <- data.frame(
     Species = c("Rainbow Trout", "Coho"),
     Caught = c(5, 2)
   )
-  
+
   sbf_create_db(db_name = "database")
-  
-  sbf_execute_db("CREATE TABLE species (
+
+  sbf_execute_db(
+    "CREATE TABLE species (
                 Species TEXT,
-                Caught INTEGER)")
-  
-  sbf_execute_db("CREATE TABLE sites (
+                Caught INTEGER)"
+  )
+
+  sbf_execute_db(
+    "CREATE TABLE sites (
                 Places TEXT,
-                Activity TEXT)")
-  
+                Activity TEXT)"
+  )
+
   sbf_save_data_to_db(sites, db_name = "database")
   sbf_save_data_to_db(species, db_name = "database")
-  
+
   # write db to excel tables
   sbf_save_db_to_workbook(
     workbook_name = "data",
@@ -1921,13 +2344,12 @@ test_that("exclude table function working for db to workbook", {
     exclude_tables = "species"
   )
   # do tests
-  site_data <- readxl::read_excel(file.path(path, "excel/data.xlsx"),
-                                  sheet = 1
-  )
+  site_data <- readxl::read_excel(file.path(path, "excel/data.xlsx"), sheet = 1)
   expect_identical(colnames(site_data), c("Places", "Activity"))
-  
-  expect_error(readxl::read_excel(file.path(path, "excel/data.xlsx"),
-                                  sheet = 2
+
+  expect_error(readxl::read_excel(
+    file.path(path, "excel/data.xlsx"),
+    sheet = 2
   ))
 })
 
@@ -1936,22 +2358,23 @@ test_that("expect empty table when all tables are excluded", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   # create test data
   sites <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing")
   )
-  
-  
+
   sbf_create_db(db_name = "database")
-  
-  sbf_execute_db("CREATE TABLE sites (
+
+  sbf_execute_db(
+    "CREATE TABLE sites (
                 Places TEXT,
-                Activity TEXT)")
-  
+                Activity TEXT)"
+  )
+
   sbf_save_data_to_db(sites, db_name = "database")
-  
+
   # write db to excel tables
   sbf_save_db_to_workbook(
     workbook_name = "data",
@@ -1960,7 +2383,7 @@ test_that("expect empty table when all tables are excluded", {
   )
   # do tests
   data <- readxl::read_excel(file.path(path, "excel/data.xlsx"))
-  
+
   expect_equal(nrow(data), 0L)
   expect_equal(colnames(data), character(0))
 })
@@ -1970,23 +2393,25 @@ test_that("checking return value for sbf_save_data_to_db", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   # create test data
   sites <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing")
   )
   sbf_create_db(db_name = "database")
-  sbf_execute_db("CREATE TABLE sites (
+  sbf_execute_db(
+    "CREATE TABLE sites (
                 Places TEXT,
-                Activity TEXT)")
+                Activity TEXT)"
+  )
   sbf_save_data_to_db(sites, db_name = "database")
   # do tests
   return_path <- sbf_save_db_to_workbook(
     workbook_name = "data",
     db_name = "database"
   )
-  
+
   expect_match(return_path, "output/excel/data.xlsx$")
 })
 
@@ -1995,21 +2420,24 @@ test_that("save df as gpkg with sf point column", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
     X = c(53.350808, 53.640981),
     Y = c(-132.280579, -132.055175)
   )
-  
+
   sf <- convert_coords_to_sfc(data)
-  
+
   sbf_save_gpkg(sf)
-  expect_output(gpkg <- sf::st_read(file.path(path, "gpkg/sf.gpkg")), "^Reading layer `sf' from data source ")
-  
+  expect_output(
+    gpkg <- sf::st_read(file.path(path, "gpkg/sf.gpkg")),
+    "^Reading layer `sf' from data source "
+  )
+
   expect_s3_class(gpkg, "sf")
-  
+
   expect_identical(colnames(gpkg), c("Places", "Activity", "geom"))
   sf <- convert_sfc_to_coords(gpkg, "geom")
   expect_identical(sf$Places, data$Places)
@@ -2023,16 +2451,16 @@ test_that("save sf as gpkg errors if gpkg", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
     X = c(53.350808, 53.640981),
     Y = c(-132.280579, -132.055175)
   )
-  
+
   gpkg <- convert_coords_to_sfc(data)
-  
+
   expect_error(sbf_save_gpkg(gpkg), "'gpkg' is a reserved geopackage prefix\\.")
 })
 
@@ -2041,20 +2469,23 @@ test_that("save sf as gpkg time", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     time = hms::as_hms("12:01:03"),
     X = c(53.350808),
     Y = c(-132.280579)
   )
-  
+
   sff <- convert_coords_to_sfc(data)
-  
+
   sbf_save_gpkg(sff)
-  expect_output(gpkg <- sf::st_read(file.path(path, "gpkg/sff.gpkg")), "^Reading layer `sff' from data source ")
-  
+  expect_output(
+    gpkg <- sf::st_read(file.path(path, "gpkg/sff.gpkg")),
+    "^Reading layer `sff' from data source "
+  )
+
   expect_s3_class(gpkg, "sf")
-  
+
   expect_identical(colnames(gpkg), c("time", "geom"))
   sf <- convert_sfc_to_coords(gpkg, "geom")
   expect_identical(sf$time, as.character(data$time))
@@ -2067,7 +2498,7 @@ test_that("save df as gpkg with linstring column and sf point", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
@@ -2076,23 +2507,35 @@ test_that("save df as gpkg with linstring column and sf point", {
     X2 = c(53.350808, 53.640981),
     Y2 = c(-132.280579, -132.055175)
   )
-  
+
   sf <- convert_coords_to_sfc(data)
-  sf <- convert_coords_to_sfc(sf,
-                              coords = c("X2", "Y2"),
-                              sfc_name = "geometry2"
+  sf <- convert_coords_to_sfc(
+    sf,
+    coords = c("X2", "Y2"),
+    sfc_name = "geometry2"
   )
-  
+
   sf <- sf::st_cast(sf, "LINESTRING")
-  
-  expect_warning(sbf_save_gpkg(sf), "Dropping column\\(s\\) geometry of class\\(es\\) sfc_POINT")
-  expect_output(gpkg <- sf::st_read(file.path(path, "gpkg/sf.gpkg")), "^Reading layer `sf' from data source ")
-  
+
+  expect_warning(
+    sbf_save_gpkg(sf),
+    "Dropping column\\(s\\) geometry of class\\(es\\) sfc_POINT"
+  )
+  expect_output(
+    gpkg <- sf::st_read(file.path(path, "gpkg/sf.gpkg")),
+    "^Reading layer `sf' from data source "
+  )
+
   expect_s3_class(gpkg, "sf")
-  
-  expect_identical(colnames(gpkg), c(
-    "Places", "Activity", "geom"
-  ))
+
+  expect_identical(
+    colnames(gpkg),
+    c(
+      "Places",
+      "Activity",
+      "geom"
+    )
+  )
   expect_s3_class(gpkg$geom, "sfc_LINESTRING")
   expect_identical(gpkg$Places, data$Places)
   expect_identical(gpkg$Activity, data$Activity)
@@ -2103,7 +2546,7 @@ test_that("save sfs as gpkg and ignores data frame", {
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
@@ -2116,11 +2559,14 @@ test_that("save sfs as gpkg and ignores data frame", {
   expect_identical(length(files), 2L)
   expect_match(files[1], "output/gpkg/sf\\.gpkg")
   expect_match(files[2], "output/gpkg/sf2\\.gpkg")
-  
-  expect_output(gpkg <- sf::st_read(file.path(path, "gpkg/sf2.gpkg")), "^Reading layer `sf2' from data source ")
-  
+
+  expect_output(
+    gpkg <- sf::st_read(file.path(path, "gpkg/sf2.gpkg")),
+    "^Reading layer `sf2' from data source "
+  )
+
   expect_s3_class(gpkg, "sf")
-  
+
   expect_identical(colnames(gpkg), c("Activity", "geom"))
   sf <- convert_sfc_to_coords(gpkg, "geom")
   expect_identical(sf$Activity, "boating")
@@ -2133,7 +2579,7 @@ test_that("save sf as gpkgs with linstring column and sf point and all_sfc = FAL
   path <- file.path(withr::local_tempdir(), "output")
   sbf_set_main(path)
   withr::defer(sbf_reset())
-  
+
   data <- data.frame(
     Places = c("Yakoun Lake", "Meyer Lake"),
     Activity = c("boating", "fishing"),
@@ -2142,26 +2588,41 @@ test_that("save sf as gpkgs with linstring column and sf point and all_sfc = FAL
     Y2 = c(53.350808, 53.640981),
     X2 = c(-132.280579, -132.055175)
   )
-  
+
   sf <- convert_coords_to_sfc(data)
-  sf <- convert_coords_to_sfc(sf,
-                              coords = c("X2", "Y2"),
-                              sfc_name = "geometry2"
+  sf <- convert_coords_to_sfc(
+    sf,
+    coords = c("X2", "Y2"),
+    sfc_name = "geometry2"
   )
-  
+
   sf$geometry <- sf::st_cast(sf$geometry, "LINESTRING")
-  
-  expect_warning(expect_warning(files <- sbf_save_gpkgs(), "Dropping column\\(s\\) geometry of class\\(es\\) sfc_LINESTRING"), "Dropping column\\(s\\) geometry2 of class\\(es\\) sfc_POINT")
+
+  expect_warning(
+    expect_warning(
+      files <- sbf_save_gpkgs(),
+      "Dropping column\\(s\\) geometry of class\\(es\\) sfc_LINESTRING"
+    ),
+    "Dropping column\\(s\\) geometry2 of class\\(es\\) sfc_POINT"
+  )
   expect_length(files, 2L)
   expect_match(files[1], "output/gpkg/sf_geometry.gpkg")
   expect_match(files[2], "output/gpkg/sf.gpkg")
-  expect_output(gpkg <- sf::st_read(file.path(path, "gpkg/sf.gpkg")), "^Reading layer `sf' from data source ")
-  
+  expect_output(
+    gpkg <- sf::st_read(file.path(path, "gpkg/sf.gpkg")),
+    "^Reading layer `sf' from data source "
+  )
+
   expect_s3_class(gpkg, "sf")
-  
-  expect_identical(colnames(gpkg), c(
-    "Places", "Activity", "geom"
-  ))
+
+  expect_identical(
+    colnames(gpkg),
+    c(
+      "Places",
+      "Activity",
+      "geom"
+    )
+  )
   expect_s3_class(gpkg$geom, "sfc_POINT")
   expect_identical(gpkg$Places, data$Places)
   expect_identical(gpkg$Activity, data$Activity)
@@ -2239,7 +2700,7 @@ test_that("`sbf_load_numbers_recursive()` drops only exact matches.", {
   numbers_bone <- sbf_load_numbers_recursive(drop = "bone")
   numbers_bone$file <- NULL
 
-  expect_snapshot(numbers_bone)  
+  expect_snapshot(numbers_bone)
 
   numbers_onebone <- sbf_load_numbers_recursive(drop = c("one", "bone"))
   numbers_onebone$file <- NULL
@@ -2274,27 +2735,45 @@ test_that("multiline captions are handled correctly", {
   withr::defer(sbf_reset())
 
   x <- data.frame(z = 1L)
-  sbf_save_table(x, x_name = "x", caption = "a\nmultiline
-  caption", tag = "tag-1")
+  sbf_save_table(
+    x,
+    x_name = "x",
+    caption = "a\nmultiline
+  caption",
+    tag = "tag-1"
+  )
 
   yaml_file <- file.path(sbf_get_main(), "tables", "x.yaml")
   expect_true(file.exists(yaml_file))
   expect_false(file.exists(file.path(sbf_get_main(), "tables", "x.rda")))
 
   meta <- yaml::read_yaml(yaml_file)
-  expect_identical( # with visible new line
+  expect_identical(
+    # with visible new line
     meta,
-    list(caption = "a\nmultiline
-  caption", report = TRUE, tag = "tag-1", notes = "")
+    list(
+      caption = "a\nmultiline
+  caption",
+      report = TRUE,
+      tag = "tag-1",
+      notes = ""
+    )
   )
-  expect_identical( # with a newline character \n
+  expect_identical(
+    # with a newline character \n
     meta,
-    list(caption = "a\nmultiline\n  caption", report = TRUE, tag = "tag-1", notes = "")
+    list(
+      caption = "a\nmultiline\n  caption",
+      report = TRUE,
+      tag = "tag-1",
+      notes = ""
+    )
   )
 
-  expect_true(all(c("caption: |-",
-                    paste0("  ", c("a", "multiline", "  caption")))
-                  %in% readLines(yaml_file)))
+  expect_true(all(
+    c("caption: |-", paste0("  ", c("a", "multiline", "  caption"))) %in%
+      readLines(yaml_file)
+  ))
 })
 
 test_that("legacy .rda metadata is still readable", {
@@ -2406,16 +2885,19 @@ test_that("notes argument is saved for numbers and strings", {
   )
 })
 
- test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
+test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
   sbf_reset()
   sbf_set_main(file.path(withr::local_tempdir(), "output"))
   withr::defer(sbf_reset())
-     
+
   gp <- ggplot2::ggplot() +
-  ggplot2::geom_point(ggplot2::aes(3, 3))
-    
-  lifecycle::expect_deprecated(sbf_save_plot(x = gp, x_name = "plot-1", drop_uninformative_cols = TRUE), 
-  p0("The `drop_uninformative_cols` argument of `sbf_save_plot",
-       "\\(\\)` is deprecated as of subfoldr2"))
+    ggplot2::geom_point(ggplot2::aes(3, 3))
+
+  lifecycle::expect_deprecated(
+    sbf_save_plot(x = gp, x_name = "plot-1", drop_uninformative_cols = TRUE),
+    p0(
+      "The `drop_uninformative_cols` argument of `sbf_save_plot",
+      "\\(\\)` is deprecated as of subfoldr2"
+    )
+  )
 })
- 

--- a/tests/testthat/test-sub.R
+++ b/tests/testthat/test-sub.R
@@ -20,7 +20,8 @@ test_that("sub", {
   expect_identical(sbf_up_sub(), "sub/tub/bub")
   expect_identical(sbf_up_sub(2), "sub")
   expect_identical(sbf_up_sub(), character(0))
-  expect_error(sbf_up_sub(3),
+  expect_error(
+    sbf_up_sub(3),
     "^`n` [(]3[)] must not exceed the number of subfolders [(]0[)][.]$",
     class = "chk_error"
   )


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)