### PR TITLE
Write empty plot csv and xlsx rather than skipping

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -798,7 +798,7 @@ sbf_save_plot <- function(
   sheet_list <- purrr::compact(purrr::list_flatten(sheet_list))
   # a plot with data or layers always gets an xlsx, even an empty one,
   # so a stale file from a previous save cannot outlive its sheets
-  has_sheet_source <- is.data.frame(data) ||
+  has_sheet_source <- !is_waiver(data) ||
     any(vapply(plot_list, function(p) length(p@layers) > 0L, TRUE))
   if (has_sheet_source) {
     save_xlsx(sheet_list, "plots", sub = sub, main = main, x_name = x_name)

--- a/R/save.R
+++ b/R/save.R
@@ -798,7 +798,7 @@ sbf_save_plot <- function(
   sheet_list <- purrr::compact(purrr::list_flatten(sheet_list))
   # a plot with data or layers always gets an xlsx, even an empty one,
   # so a stale file from a previous save cannot outlive its sheets
-  has_sheet_source <- !is_waiver(data) ||
+  has_sheet_source <- !ggplot2::is_waiver(data) ||
     any(vapply(plot_list, function(p) length(p@layers) > 0L, TRUE))
   if (has_sheet_source) {
     save_xlsx(sheet_list, "plots", sub = sub, main = main, x_name = x_name)

--- a/R/save.R
+++ b/R/save.R
@@ -781,9 +781,12 @@ sbf_save_plot <- function(
     if (drop_uninformative_cols) {
       data <- tidyplus::drop_uninformative_columns(data)
     }
-    if (nrow(data) && ncol(data) && nrow(data) <= csv) {
-      save_csv(data, "plots", sub = sub, main = main, x_name = x_name)
+    # an empty csv is still written so a stale file from a previous save
+    # cannot outlive the data it represented
+    if (nrow(data) > csv) {
+      data <- data[integer(0), , drop = FALSE]
     }
+    save_csv(data, "plots", sub = sub, main = main, x_name = x_name)
   }
 
   sheet_list <- purrr::imap(plot_list, function(p, i) {
@@ -793,7 +796,11 @@ sbf_save_plot <- function(
     )
   })
   sheet_list <- purrr::compact(purrr::list_flatten(sheet_list))
-  if (length(sheet_list)) {
+  # a plot with data or layers always gets an xlsx, even an empty one,
+  # so a stale file from a previous save cannot outlive its sheets
+  has_sheet_source <- is.data.frame(data) ||
+    any(vapply(plot_list, function(p) length(p@layers) > 0L, TRUE))
+  if (has_sheet_source) {
     save_xlsx(sheet_list, "plots", sub = sub, main = main, x_name = x_name)
   }
 

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -1073,6 +1073,7 @@ test_that("plot", {
   expect_identical(
     list.files(file.path(sbf_get_main(), "plots")),
     c(
+      "plot.csv", # empty as data exceeds csv row limit
       "plot.png",
       "plot.rds",
       "plot.xlsx",
@@ -1085,8 +1086,10 @@ test_that("plot", {
       "y.rds",
       "y.xlsx",
       "y.yaml", # has data but no layers
+      "z.csv", # empty as one-row data is uninformative
       "z.png",
       "z.rds",
+      "z.xlsx", # empty as one-row data is uninformative
       "z.yaml" # dataset has only one row and no layers
     )
   )
@@ -1172,6 +1175,7 @@ test_that("plot", {
       "p_layers.rds",
       "p_layers.xlsx",
       "p_layers.yaml", # has data & layers
+      "plot.csv", # empty as data exceeds csv row limit
       "plot.png",
       "plot.rds",
       "plot.xlsx",
@@ -1184,8 +1188,10 @@ test_that("plot", {
       "y.rds",
       "y.xlsx",
       "y.yaml", # has data but no layers
+      "z.csv", # empty as one-row data is uninformative
       "z.png",
       "z.rds",
+      "z.xlsx", # empty as one-row data is uninformative
       "z.yaml" # has one-row data and no layers
     )
   )
@@ -1315,6 +1321,7 @@ test_that("plot", {
       "p_patches.rds",
       "p_patches.xlsx",
       "p_patches.yaml",
+      "plot.csv", # empty as data exceeds csv row limit
       "plot.png",
       "plot.rds",
       "plot.xlsx",
@@ -1327,8 +1334,10 @@ test_that("plot", {
       "y.rds",
       "y.xlsx",
       "y.yaml", # has data but no layers
+      "z.csv", # empty as one-row data is uninformative
       "z.png",
       "z.rds",
+      "z.xlsx", # empty as one-row data is uninformative
       "z.yaml" # has one-row data and no layers
     )
   )

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2901,3 +2901,63 @@ test_that("drop_uninformative_cols is being soft-deprecated with a warning.", {
     )
   )
 })
+
+test_that("plot with uninformative data saves empty csv and xlsx over stale files", {
+  sbf_reset()
+  sbf_set_main(file.path(withr::local_tempdir(), "output"))
+  sbf_close_windows()
+
+  y <- ggplot2::ggplot(
+    data = data.frame(x = 1:3, y = 2:4),
+    ggplot2::aes(x = x, y = y)
+  ) +
+    ggplot2::geom_point()
+  sbf_save_plot(y)
+
+  csv_file <- file.path(sbf_get_main(), "plots/y.csv")
+  xlsx_file <- file.path(sbf_get_main(), "plots/y.xlsx")
+  expect_gt(length(readLines(csv_file)), 1L)
+  expect_true(file.exists(xlsx_file))
+  xlsx_size <- file.size(xlsx_file)
+
+  y <- ggplot2::ggplot(
+    data = data.frame(x = 1, y = 2),
+    ggplot2::aes(x = x, y = y)
+  )
+  sbf_save_plot(y)
+
+  expect_true(file.exists(csv_file))
+  expect_identical(readLines(csv_file), character(0))
+  expect_true(file.exists(xlsx_file))
+  expect_lt(file.size(xlsx_file), xlsx_size)
+})
+
+test_that("plot data exceeding csv limit saves empty csv over stale file", {
+  sbf_reset()
+  sbf_set_main(file.path(withr::local_tempdir(), "output"))
+  sbf_close_windows()
+
+  data <- data.frame(x = 1:3, y = 2:4)
+  y <- ggplot2::ggplot(data = data, ggplot2::aes(x = x, y = y))
+  sbf_save_plot(y)
+
+  csv_file <- file.path(sbf_get_main(), "plots/y.csv")
+  expect_identical(nrow(read.csv(csv_file)), 3L)
+
+  sbf_save_plot(y, csv = 2L)
+  expect_true(file.exists(csv_file))
+  expect_identical(nrow(read.csv(csv_file)), 0L)
+})
+
+test_that("plot with no data and no layers saves no csv or xlsx", {
+  sbf_reset()
+  sbf_set_main(file.path(withr::local_tempdir(), "output"))
+  sbf_close_windows()
+
+  x <- ggplot2::ggplot()
+  sbf_save_plot(x)
+  expect_identical(
+    list.files(file.path(sbf_get_main(), "plots")),
+    c("x.png", "x.rds", "x.yaml")
+  )
+})

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2936,7 +2936,7 @@ test_that("plot with uninformative data saves empty csv and xlsx over stale file
   sbf_save_plot(y)
 
   expect_true(file.exists(csv_file))
-  expect_identical(readLines(csv_file), character(0))
+  expect_identical(readLines(csv_file), character(0)) # all columns were uninformative
   expect_true(file.exists(xlsx_file))
   expect_lt(file.size(xlsx_file), xlsx_size)
 })


### PR DESCRIPTION
## Summary
`sbf_save_plot()` skipped writing the csv when the plot data was empty after `tidyplus::drop_uninformative_columns()` or exceeded the `csv` row limit, and skipped the xlsx when all sheets were empty. A stale csv or xlsx from a previous save of the same plot could therefore persist and misrepresent the current plot. An empty csv is now always written when the plot has a data frame (truncated to zero rows when over the `csv` limit), and an empty xlsx workbook is written whenever the plot has data or layers. A plot with no data and no layers still writes neither file, unchanged. This also unblocks the three pre-existing CI failures tracked in poissonconsulting/subreport#46, whose root cause is the missing csv; a follow-up subreport PR will update its test expectations to include the xlsx.

## Verification
```r
library(subfoldr2)
sbf_set_main(file.path(tempdir(), "output"))
p <- ggplot2::ggplot(data.frame(x = 1:3, y = 2:4), ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()
sbf_save_plot(p, x_name = "y")
length(readLines(file.path(sbf_get_main(), "plots/y.csv")))  # 4 (informative data)

p <- ggplot2::ggplot(data.frame(x = 1, y = 2), ggplot2::aes(x = x, y = y))
sbf_save_plot(p, x_name = "y")  # all columns uninformative
file.size(file.path(sbf_get_main(), "plots/y.csv"))  # 0: empty, stale data gone
file.exists(file.path(sbf_get_main(), "plots/y.xlsx"))  # TRUE: empty workbook
```

Local test suite: FAIL 4 | PASS 735 — the 4 failures are pre-existing and unrelated (a newer chk version appends `, not S3 class '...'` to error messages the tests match with an exact regex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)