### PR TITLE
Suppress test messages

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -151,11 +151,15 @@ export(sbf_upload_flobs_to_db)
 export(sbf_write_datas_to_xlsx)
 import(chk)
 import(readwritesqlite)
-importFrom(dttr2,dtt_default_tz)
-importFrom(dttr2,dtt_sys_date_time)
+importFrom(dttr2,
+  dtt_default_tz,
+  dtt_sys_date_time
+)
 importFrom(fs,path_split)
 importFrom(stats,setNames)
-importFrom(tibble,as_tibble)
-importFrom(tibble,tibble)
+importFrom(tibble,
+  as_tibble,
+  tibble
+)
 importFrom(tools,file_ext)
 importFrom(yesno,yesno)

--- a/tests/testthat/test-save-load.R
+++ b/tests/testthat/test-save-load.R
@@ -2809,14 +2809,14 @@ test_that("sbf_convert_meta converts legacy .rda to .yaml and deletes .rda", {
   file.remove(yaml_file)
   saveRDS(meta, file.path(sbf_get_main(), "tables", "x.rda"))
 
-  converted <- sbf_convert_meta(ask = FALSE)
+  suppressMessages(converted <- sbf_convert_meta(ask = FALSE))
   expect_identical(converted, yaml_file)
   expect_true(file.exists(yaml_file))
   expect_false(file.exists(file.path(sbf_get_main(), "tables", "x.rda")))
   expect_identical(yaml::read_yaml(yaml_file), meta)
 
   # nothing left to convert
-  expect_identical(sbf_convert_meta(ask = FALSE), character(0))
+  suppressMessages(expect_identical(sbf_convert_meta(ask = FALSE), character(0)))
 })
 
 test_that("notes argument is saved to metadata", {


### PR DESCRIPTION
there were two messages in the tests that were cluttering the test output. additionally, the NAMESPACE formatting is now a little different: functions from the same package are imported via the same `importFrom()` call.